### PR TITLE
fix warning of psycopg2 getting renamed

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,6 @@ masonite = "==2.1.0b1.post1"
 waitress = "==1.1.0"
 
 [scripts]
-postgres = "pipenv install psycopg2"
+postgres = "pipenv install psycopg2-binary"
 mysql = "pipenv install PyMySQL"
 key = "craft key --store"


### PR DESCRIPTION
UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.