### PR TITLE
fixed flashing of session when bytes exists

### DIFF
--- a/masonite/auth/Auth.py
+++ b/masonite/auth/Auth.py
@@ -85,7 +85,7 @@ class Auth:
                     model.remember_token = remember_token
                     model.save()
                     self.request.app().make('AuthManager').driver(self.driver).save(remember_token, model=model)
-                    
+
                 self.request.set_user(model)
                 return model
 

--- a/masonite/request.py
+++ b/masonite/request.py
@@ -809,6 +809,9 @@ class Request(Extendable):
             return
 
         for key, value in self.all().items():
+            if not isinstance(value, str):
+                continue
+
             self.session.flash(key, value)
 
     def is_named_route(self, name, params={}):

--- a/masonite/request.py
+++ b/masonite/request.py
@@ -809,7 +809,7 @@ class Request(Extendable):
             return
 
         for key, value in self.all().items():
-            if not isinstance(value, str):
+            if isinstance(value, bytes):
                 continue
 
             self.session.flash(key, value)

--- a/tests/core/test_session.py
+++ b/tests/core/test_session.py
@@ -130,10 +130,11 @@ class TestSession(unittest.TestCase):
                 'key1': 'val1',
                 'key2': 'val2',
             }
-            request.with_input()
             session = self.app.make('SessionManager').driver(driver)
-            self.assertFalse(session.has('key1'))
-            self.assertFalse(session.has('key2'))
+            request.session = session
+            request.with_input()
+            self.assertTrue(session.has('key1'))
+            self.assertTrue(session.has('key2'))
 
     def test_can_redirect_with_bytes_inputs(self):
         for driver in ('memory', 'cookie'):

--- a/tests/core/test_session.py
+++ b/tests/core/test_session.py
@@ -134,3 +134,18 @@ class TestSession(unittest.TestCase):
             session = self.app.make('SessionManager').driver(driver)
             self.assertFalse(session.has('key1'))
             self.assertFalse(session.has('key2'))
+
+    def test_can_redirect_with_bytes_inputs(self):
+        for driver in ('memory', 'cookie'):
+            
+            request = self.app.make('Request')
+            session = self.app.make('SessionManager').driver(driver)
+            request.request_variables = {
+                'byte': 'val1'.encode('utf-8'),
+                'key2': 'val2',
+            }
+            request.session = session
+
+            request.with_input()
+            self.assertFalse(session.has('byte'))
+            self.assertTrue(session.has('key2'))


### PR DESCRIPTION
Closes #193 

Was having issues flashing bytes because it needs to be saved to the session which needed to save to a cookie. Now the request session does not flash anything other than strings