### PR TITLE
improved query parsing

### DIFF
--- a/src/masonite/helpers/routes.py
+++ b/src/masonite/helpers/routes.py
@@ -210,9 +210,9 @@ def create_matchurl(url, route):
 def query_parse(query_string):
     d = {}
     for key, value in parse_qs(query_string).items():
-        match = re.match(r'(?P<key>[^\[]+)\[(?P<value>[^\]]+)\]', key)
-        if match:
-            gd = match.groupdict()
+        regex_match = re.match(r'(?P<key>[^\[]+)\[(?P<value>[^\]]+)\]', key)
+        if regex_match:
+            gd = regex_match.groupdict()
             d.setdefault(gd['key'], {})[gd['value']] = value[0]
         else:
             d.update({key: value[0]})

--- a/src/masonite/helpers/routes.py
+++ b/src/masonite/helpers/routes.py
@@ -1,8 +1,9 @@
 """Helper Functions for RouteProvider."""
 
-from .misc import deprecated
-from urllib.parse import parse_qs
 import re
+from urllib.parse import parse_qs
+
+from .misc import deprecated
 
 
 def flatten_routes(routes):
@@ -204,6 +205,7 @@ def create_matchurl(url, route):
         return route._compiled_regex
 
     return route._compiled_regex_end
+
 
 def query_parse(query_string):
     d = {}

--- a/src/masonite/helpers/routes.py
+++ b/src/masonite/helpers/routes.py
@@ -1,6 +1,8 @@
 """Helper Functions for RouteProvider."""
 
 from .misc import deprecated
+from urllib.parse import parse_qs
+import re
 
 
 def flatten_routes(routes):
@@ -202,3 +204,15 @@ def create_matchurl(url, route):
         return route._compiled_regex
 
     return route._compiled_regex_end
+
+def query_parse(query_string):
+    d = {}
+    for key, value in parse_qs(query_string).items():
+        match = re.match(r'(?P<key>[^\[]+)\[(?P<value>[^\]]+)\]', key)
+        if match:
+            gd = match.groupdict()
+            d.setdefault(gd['key'], {})[gd['value']] = value[0]
+        else:
+            d.update({key: value[0]})
+
+    return d

--- a/src/masonite/request.py
+++ b/src/masonite/request.py
@@ -11,7 +11,6 @@ of this class.
 import re
 from cgi import MiniFieldStorage
 from http import cookies
-from urllib.parse import parse_qsl
 
 import tldextract
 from cryptography.fernet import InvalidToken
@@ -20,7 +19,7 @@ from .exceptions import InvalidHTTPStatusCode, RouteException
 from .helpers import Dot as DictDot
 from .helpers import clean_request_input, dot
 from .helpers.Extendable import Extendable
-from .helpers.routes import compile_route_to_regex
+from .helpers.routes import compile_route_to_regex, query_parse
 from .helpers.status import response_statuses
 from .helpers.time import cookie_expire_time
 
@@ -221,9 +220,10 @@ class Request(Extendable):
         Arguments:
             variables {string|dict}
         """
+        # vv = variables
         if isinstance(variables, str):
-            variables = dict(parse_qsl(variables))
-
+            variables = query_parse(variables)
+        
         try:
             self.request_variables = {}
             for name in variables.keys():

--- a/src/masonite/request.py
+++ b/src/masonite/request.py
@@ -223,7 +223,7 @@ class Request(Extendable):
         # vv = variables
         if isinstance(variables, str):
             variables = query_parse(variables)
-        
+
         try:
             self.request_variables = {}
             for name in variables.keys():

--- a/src/masonite/testing/MockRoute.py
+++ b/src/masonite/testing/MockRoute.py
@@ -35,13 +35,13 @@ class MockRoute:
 
     def canView(self):
         return self.ok()
-    
+
     def get_string_response(self):
         response = self.container.make('Response')
 
         if isinstance(response, str):
             return response
-        
+
         return response.decode('utf-8')
 
     def hasJson(self, key, value=''):

--- a/src/masonite/testing/MockRoute.py
+++ b/src/masonite/testing/MockRoute.py
@@ -35,9 +35,18 @@ class MockRoute:
 
     def canView(self):
         return self.ok()
+    
+    def get_string_response(self):
+        response = self.container.make('Response')
+
+        if isinstance(response, str):
+            return response
+        
+        return response.decode('utf-8')
 
     def hasJson(self, key, value=''):
-        response = json.loads(self.container.make('Response'))
+
+        response = json.loads(self.get_string_response())
         if isinstance(key, dict):
             for item_key, key_value in key.items():
                 if not Dot().dot(item_key, response, False) == key_value:
@@ -46,7 +55,7 @@ class MockRoute:
         return Dot().dot(key, response, False)
 
     def assertHasJson(self, key, value):
-        response = json.loads(self.container.make('Response'))
+        response = json.loads(self.get_string_response())
         if isinstance(key, dict):
             for item_key, key_value in key.items():
                 assert Dot().dot(item_key, response, False) == key_value
@@ -55,7 +64,7 @@ class MockRoute:
         return self
 
     def assertJsonContains(self, key, value):
-        response = json.loads(self.container.make('Response'))
+        response = json.loads(self.get_string_response())
         if not isinstance(response, list):
             raise ValueError("This method can only be used if the response is a list of elements.")
 
@@ -70,10 +79,10 @@ class MockRoute:
         return self
 
     def count(self, amount):
-        return len(json.loads(self.container.make('Response'))) == amount
+        return len(json.loads(self.get_string_response())) == amount
 
     def assertCount(self, amount):
-        response_amount = len(json.loads(self.container.make('Response')))
+        response_amount = len(json.loads(self.get_string_response()))
         assert response_amount == amount, 'Response has an count of {}. Asserted {}'.format(response_amount, amount)
         return self
 
@@ -81,14 +90,14 @@ class MockRoute:
         return self.count(amount)
 
     def hasAmount(self, key, amount):
-        response = json.loads(self.container.make('Response'))
+        response = json.loads(self.get_string_response())
         try:
             return len(response[key]) == amount
         except TypeError:
             raise TypeError("The json response key of: {} is not iterable but has the value of {}".format(key, response[key]))
 
     def assertHasAmount(self, key, amount):
-        response = json.loads(self.container.make('Response'))
+        response = json.loads(self.get_string_response())
         try:
             assert len(response[key]) == amount, '{} is not equal to {}'.format(len(response[key]), amount)
         except TypeError:
@@ -97,7 +106,7 @@ class MockRoute:
         return self
 
     def assertNotHasAmount(self, key, amount):
-        response = json.loads(self.container.make('Response'))
+        response = json.loads(self.get_string_response())
         try:
             assert not len(response[key]) == amount, '{} is equal to {} but should not be'.format(len(response[key]), amount)
         except TypeError:
@@ -212,7 +221,7 @@ class MockRoute:
         Returns:
             string
         """
-        response = self.container.make('Response')
+        response = self.get_string_response()
         if isinstance(response, str):
             return response
 

--- a/tests/core/test_requests.py
+++ b/tests/core/test_requests.py
@@ -90,6 +90,24 @@ class TestRequest(unittest.TestCase):
         }
         self.assertEqual(self.request.input('user.address.*.id'), [1, 2])
         self.assertEqual(self.request.input('user.address.*.street'), ['A Street', 'B Street'])
+    
+    def test_request_input_parses_query_string(self):
+        query_string = "filter=name"
+        self.request._set_standardized_request_variables(query_string)
+        self.request._set_standardized_request_variables(query_string)
+        self.assertEqual(self.request.input('filter'), 'name')
+
+        query_string = "filter=name&user=Joe"
+        self.request._set_standardized_request_variables(query_string)
+        self.assertEqual(self.request.input('filter'), 'name')
+        self.assertEqual(self.request.input('user'), 'Joe')
+
+        query_string = "filter[name]=Joe&filter[email]=user@email.com"
+        self.request._set_standardized_request_variables(query_string)
+        self.assertEqual(self.request.input('filter')['name'], 'Joe')
+        self.assertEqual(self.request.input('filter.name'), 'Joe')
+        self.assertEqual(self.request.input('filter')['email'], 'user@email.com')
+        self.assertEqual(self.request.input('filter.email'), 'user@email.com')
 
     def test_request_sets_and_gets_cookies(self):
         self.request.cookie('setcookie', 'value')


### PR DESCRIPTION
Closes #211 

This PR changes how query strings are parsed for Masonite 2.3.

Instead of a url like `/?filter[name]=Joe&filter[user]=bob&email=user@email.com`

parsing to:

```python
{
    "filter[name]": "Joe",
    "filter[user]": "Bob",
    "email": "user@email.com"
}
```

It will now parse into:

```python
{
    "email": "user@email.com",
    "filter": {
        "name": "Joe",
        "user": "bob"
    }
}
```