### PR TITLE
added status code tuples in controllers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ dist
 docs
 masonite.egg-info
 venv
+venv2
 .vscode
 htmlcov
 .coverage
@@ -23,3 +24,4 @@ tests/bootstrap/cache/*.txt
 .idea/
 masonite.db
 tests/uploads
+

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 init:
 	pip install masonite_cli --user
 	pip install -r requirements.txt --user
-	pip install -e . --user
+	pip install -e .
+	pip install pytest
 test:
 	python -m pytest tests
 ci:

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ requests>=2.0,<2.99
 tabulate>=0.8,<0.9
 tldextract>=2.2,<2.3
 whitenoise>=3.3
+masonite-errors

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ requests>=2.0,<2.99
 tabulate>=0.8,<0.9
 tldextract>=2.2,<2.3
 whitenoise>=3.3
-masonite-errors
+exceptionite

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         'tabulate>=0.8,<0.9',
         'tldextract>=2.2,<2.3',
         'whitenoise>=3.3',
+        'masonite-errors',
     ],
     description=meta['__description__'],
     long_description=readme,

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'tabulate>=0.8,<0.9',
         'tldextract>=2.2,<2.3',
         'whitenoise>=3.3',
-        'masonite-errors',
+        'exceptionite',
     ],
     description=meta['__description__'],
     long_description=readme,

--- a/src/masonite/exception_handler.py
+++ b/src/masonite/exception_handler.py
@@ -10,15 +10,16 @@ import platform
 import sys
 import traceback
 
+from exceptionite.errors import (Handler, SolutionsIntegration,
+                                 StackOverflowIntegration)
+
 from .app import App
 from .exceptions import DumpException
+from .helpers import config
+from .listeners import BaseExceptionListener
 from .request import Request
 from .response import Response
 from .view import View
-from .helpers import config
-from .listeners import BaseExceptionListener
-from exceptionite.errors import Handler, StackOverflowIntegration, SolutionsIntegration
-# print(Handler)
 
 package_directory = os.path.dirname(os.path.realpath(__file__))
 
@@ -90,7 +91,6 @@ class ExceptionHandler:
             StackOverflowIntegration(),
         )
         response.view(handler.render(), status=500)
-
 
 
 class DD:

--- a/src/masonite/exception_handler.py
+++ b/src/masonite/exception_handler.py
@@ -17,7 +17,6 @@ from .response import Response
 from .view import View
 from .helpers import config
 from .listeners import BaseExceptionListener
-from masonite.errors import Handler, StackOverflowIntegration, SolutionsIntegration
 
 package_directory = os.path.dirname(os.path.realpath(__file__))
 
@@ -78,6 +77,8 @@ class ExceptionHandler:
         Returns:
             None
         """
+        from masonite.errors import Handler, StackOverflowIntegration, SolutionsIntegration
+        
         stacktraceback = traceback.extract_tb(sys.exc_info()[2])
         self.run_listeners(exception, stacktraceback)
         response = self._app.make(Response)

--- a/src/masonite/exception_handler.py
+++ b/src/masonite/exception_handler.py
@@ -17,6 +17,8 @@ from .response import Response
 from .view import View
 from .helpers import config
 from .listeners import BaseExceptionListener
+from exceptionite.errors import Handler, StackOverflowIntegration, SolutionsIntegration
+# print(Handler)
 
 package_directory = os.path.dirname(os.path.realpath(__file__))
 
@@ -77,8 +79,6 @@ class ExceptionHandler:
         Returns:
             None
         """
-        from masonite.errors import Handler, StackOverflowIntegration, SolutionsIntegration
-        
         stacktraceback = traceback.extract_tb(sys.exc_info()[2])
         self.run_listeners(exception, stacktraceback)
         response = self._app.make(Response)

--- a/src/masonite/response.py
+++ b/src/masonite/response.py
@@ -149,6 +149,12 @@ class Response(Extendable):
         Returns:
             string|dict|list -- Returns the data to be returned.
         """
+
+        if isinstance(view, tuple):
+            view, status = view
+            self.request.status(status)
+        
+
         if not self.request.get_status():
             self.request.status(status)
 

--- a/src/masonite/response.py
+++ b/src/masonite/response.py
@@ -153,7 +153,6 @@ class Response(Extendable):
         if isinstance(view, tuple):
             view, status = view
             self.request.status(status)
-        
 
         if not self.request.get_status():
             self.request.status(status)

--- a/tests/core/test_response.py
+++ b/tests/core/test_response.py
@@ -58,6 +58,9 @@ class MockController:
     def single_paginator(self):
         return Paginator(User.find(1), 10)
 
+    def change_response(self):
+        return 'created', 201
+
 
 class TestResponse(TestCase):
 
@@ -77,6 +80,7 @@ class TestResponse(TestCase):
             Get('/single_paginator', MockController.single_paginator),
             Get('/single', MockController.single),
             Get('/length_aware', MockController.length_aware),
+            Get('/change/response', MockController.change_response),
         ])
     
     def setUpFactories(self):
@@ -217,3 +221,6 @@ class TestResponse(TestCase):
                 .assertHasJson('current_page', 1)
                 .assertHasJson('from', 1)
                 .assertHasJson('to', 10))
+
+    def test_can_change_response_when_returning_tuple(self):
+        self.json('GET', '/change/response').assertContains('created').assertIsStatus(201)


### PR DESCRIPTION
This pull request adds support for returning tuples to set both a response and a status:

```python
def show(self, view: View):
    return view.render('some/error/template'), 403
```