### PR TITLE
Add postfix to craft commands where appropriate.

### DIFF
--- a/src/masonite/commands/BaseScaffoldCommand.py
+++ b/src/masonite/commands/BaseScaffoldCommand.py
@@ -24,7 +24,12 @@ class BaseScaffoldCommand(Command):
     template = '/masonite/snippets/scaffold/model'
 
     def handle(self):
-        class_name = self.argument('name') + self.postfix
+        # If postfix already exists as part of the name, don't add it again
+        if self.postfix and self.argument("name").lower().endswith(self.postfix.lower()):
+            class_name = self.argument("name")
+        else:
+            class_name = self.argument("name") + self.postfix
+
         view = View(App())
         class_directory = '{}{}{}{}'.format(
             self.base_directory, class_name, self.suffix, self.file_extension)

--- a/src/masonite/commands/JobCommand.py
+++ b/src/masonite/commands/JobCommand.py
@@ -13,3 +13,4 @@ class JobCommand(BaseScaffoldCommand):
     scaffold_name = 'Job'
     template = '/masonite/snippets/scaffold/job'
     base_directory = 'app/jobs/'
+    postfix = "Job"

--- a/src/masonite/commands/MailableCommand.py
+++ b/src/masonite/commands/MailableCommand.py
@@ -13,3 +13,4 @@ class MailableCommand(BaseScaffoldCommand):
     scaffold_name = 'Mailable'
     template = '/masonite/snippets/scaffold/mailable'
     base_directory = 'app/mailable/'
+    postfix = "Mailable"

--- a/src/masonite/commands/ProviderCommand.py
+++ b/src/masonite/commands/ProviderCommand.py
@@ -13,3 +13,4 @@ class ProviderCommand(BaseScaffoldCommand):
     scaffold_name = 'Service Provider'
     base_directory = 'app/providers/'
     template = '/masonite/snippets/scaffold/provider'
+    postfix = "Provider"

--- a/src/masonite/commands/ViewCommand.py
+++ b/src/masonite/commands/ViewCommand.py
@@ -14,3 +14,4 @@ class ViewCommand(BaseScaffoldCommand):
     template = '/masonite/snippets/scaffold/view'
     file_extension = '.html'
     base_directory = 'resources/templates/'
+    postfix = "View"


### PR DESCRIPTION
This brings consistency in how the classnames are generated for various
craft commands.

Fix #236