### PR TITLE
Add namespace parameter to RouteGroup Fix/226

### DIFF
--- a/app/http/controllers/subdirectory/deep/DeepController.py
+++ b/app/http/controllers/subdirectory/deep/DeepController.py
@@ -1,0 +1,5 @@
+
+class DeepController:
+
+    def show(self):
+        return 'test'

--- a/routes/web.py
+++ b/routes/web.py
@@ -27,6 +27,9 @@ ROUTES = [
         Get('/test/2', 'TestController@show')
     ], prefix='/example'),
     RouteGroup([
+        Get('/deep/1', 'DeepController@show'),
+    ], prefix='/example', namespace='subdirectory.deep.'),
+    RouteGroup([
         Get('/test/get', 'UnitTestController@show'),
         Get('/test/param/@post_id', 'UnitTestController@param'),
         Post('/test/post', 'UnitTestController@store').middleware('test'),

--- a/src/masonite/routes.py
+++ b/src/masonite/routes.py
@@ -215,7 +215,6 @@ class BaseHttpRoute:
             import sys
             import traceback
             _, _, exc_tb = sys.exc_info()
-            tb = traceback.extract_tb(exc_tb)[-1]
             self.e = e
         except Exception as e:  # skipcq
             import sys

--- a/src/masonite/routes.py
+++ b/src/masonite/routes.py
@@ -147,6 +147,7 @@ class BaseHttpRoute:
         Returns:
             self
         """
+        self.output = output
         self._find_controller(output)
 
         if not route.startswith('/'):
@@ -172,23 +173,24 @@ class BaseHttpRoute:
         Returns:
             None
         """
+        module_location = self.module_location
         # If the output specified is a string controller
         if isinstance(controller, str):
             mod = controller.split('@')
             # If trying to get an absolute path via a string
             if mod[0].startswith('/'):
-                self.module_location = '.'.join(
+                module_location = '.'.join(
                     mod[0].replace('/', '').split('.')[0:-1])
             elif '.' in mod[0]:
                 # This is a deeper module controller
-                self.module_location = self.module_location + '.' + '.'.join(mod[0].split('.')[:-1])
+                module_location += '.' + '.'.join(mod[0].split('.')[:-1])
         else:
             if controller is None:
                 return None
 
             fully_qualified_name = controller.__qualname__
             mod = fully_qualified_name.split('.')
-            self.module_location = controller.__module__
+            module_location = controller.__module__
 
         # Gets the controller name from the output parameter
         # This is used to add support for additional modules
@@ -199,10 +201,10 @@ class BaseHttpRoute:
             # Import the module
             if isinstance(controller, str):
                 module = importlib.import_module(
-                    '{0}.'.format(self.module_location) + get_controller)
+                    '{0}.'.format(module_location) + get_controller)
             else:
                 module = importlib.import_module(
-                    '{0}'.format(self.module_location))
+                    '{0}'.format(module_location))
 
             # Get the controller from the module
             self.controller = getattr(module, get_controller)
@@ -222,6 +224,8 @@ class BaseHttpRoute:
             tb = traceback.extract_tb(exc_tb)[-1]
             self.e = e
             print('\033[93mTrouble importing controller!', str(e), '\033[0m')
+        if not self.e:
+            self.module_location = module_location
 
     def get_response(self):
         # Resolve Controller Constructor
@@ -434,7 +438,6 @@ class Get(BaseHttpRoute):
         super().__init__()
         self.method_type = ['GET']
         # self.list_middleware = []
-        self.output = output
         if route is not None and output is not None:
             self.route(route, output)
 
@@ -446,7 +449,6 @@ class Head(BaseHttpRoute):
         """Head constructor."""
         super().__init__()
         self.method_type = ['HEAD']
-        self.output = output
         if route is not None and output is not None:
             self.route(route, output)
 
@@ -458,7 +460,6 @@ class Post(BaseHttpRoute):
         """Post constructor."""
         super().__init__()
         self.method_type = ['POST']
-        self.output = output
         if route is not None and output is not None:
             self.route(route, output)
 
@@ -474,7 +475,6 @@ class Match(BaseHttpRoute):
 
         # Make all method types in list uppercase
         self.method_type = [x.upper() for x in method_type]
-        self.output = output
         if route is not None and output is not None:
             self.route(route, output)
 
@@ -486,7 +486,6 @@ class Put(BaseHttpRoute):
         """Put constructor."""
         super().__init__()
         self.method_type = ['PUT']
-        self.output = output
         if route is not None and output is not None:
             self.route(route, output)
 
@@ -498,7 +497,6 @@ class Patch(BaseHttpRoute):
         """Patch constructor."""
         super().__init__()
         self.method_type = ['PATCH']
-        self.output = output
         if route is not None and output is not None:
             self.route(route, output)
 
@@ -510,7 +508,6 @@ class Delete(BaseHttpRoute):
         """Delete constructor."""
         super().__init__()
         self.method_type = ['DELETE']
-        self.output = output
         if route is not None and output is not None:
             self.route(route, output)
 
@@ -522,7 +519,6 @@ class Connect(BaseHttpRoute):
         """Connect constructor."""
         super().__init__()
         self.method_type = ['CONNECT']
-        self.output = output
         if route is not None and output is not None:
             self.route(route, output)
 
@@ -534,7 +530,6 @@ class Options(BaseHttpRoute):
         """Options constructor."""
         super().__init__()
         self.method_type = ['OPTIONS']
-        self.output = output
         if route is not None and output is not None:
             self.route(route, output)
 
@@ -549,7 +544,6 @@ class Trace(BaseHttpRoute):
         """Trace constructor."""
         super().__init__()
         self.method_type = ['TRACE']
-        self.output = output
         if route is not None and output is not None:
             self.route(route, output)
 

--- a/src/masonite/routes.py
+++ b/src/masonite/routes.py
@@ -221,7 +221,6 @@ class BaseHttpRoute:
             import sys
             import traceback
             _, _, exc_tb = sys.exc_info()
-            tb = traceback.extract_tb(exc_tb)[-1]
             self.e = e
             print('\033[93mTrouble importing controller!', str(e), '\033[0m')
         if not self.e:

--- a/src/masonite/routes.py
+++ b/src/masonite/routes.py
@@ -705,6 +705,7 @@ class RouteGroup:
                 route.output = namespace + route.output
                 route._find_controller(route.output)
 
+
 class Resource:
 
     def __new__(cls, base='', controller='', only=['index', 'create', 'store', 'show', 'edit', 'update', 'destroy'], names={}):

--- a/src/masonite/routes.py
+++ b/src/masonite/routes.py
@@ -699,6 +699,8 @@ class RouteGroup:
         Arguments:
             namespace {str} -- String to add to find controllers for all Routes.
         """
+        if not namespace.endswith('.'):
+            namespace += '.'
         for route in self.routes:
             if isinstance(route.output, str):
                 route.e = False # reset any previous find_controller attempt

--- a/src/masonite/routes.py
+++ b/src/masonite/routes.py
@@ -706,7 +706,7 @@ class RouteGroup:
             namespace {str} -- String to add to find controllers for all Routes.
         """
         for route in self.routes:
-            if route.output is not None:
-                route.e = False
+            if isinstance(route.output, str):
+                route.e = False # reset any previous find_controller attempt
                 route.output = namespace + route.output
                 route._find_controller(route.output)

--- a/src/masonite/routes.py
+++ b/src/masonite/routes.py
@@ -703,6 +703,6 @@ class RouteGroup:
             namespace += '.'
         for route in self.routes:
             if isinstance(route.output, str):
-                route.e = False # reset any previous find_controller attempt
+                route.e = False  # reset any previous find_controller attempt
                 route.output = namespace + route.output
                 route._find_controller(route.output)

--- a/tests/core/test_routes.py
+++ b/tests/core/test_routes.py
@@ -140,14 +140,6 @@ class TestRoutes(unittest.TestCase):
         self.assertEqual(['auth', 'user'], routes[1].list_middleware)
         self.assertEqual(['test', 'test2', 'auth', 'user'], routes[2].list_middleware)
 
-    def test_group_route_namespace_using_route_values_in_constructor(self):
-        routes = RouteGroup([
-            Get('/test/1', 'SubController@show'),
-        ], namespace='subdirectory.')
-
-        self.assertIsInstance(routes, list)
-        self.assertEqual(SubController, routes[0].controller)
-
     def test_group_route_namespace(self):
         routes = RouteGroup([
             Get().route('/test/1', 'SubController@show'),
@@ -160,6 +152,16 @@ class TestRoutes(unittest.TestCase):
         routes = RouteGroup([
             RouteGroup([
                 Get().route('/test/1', 'DeepController@show'),
+            ], namespace='deep.')
+        ], namespace='subdirectory.')
+
+        self.assertIsInstance(routes, list)
+        self.assertEqual(DeepController, routes[0].controller)
+
+    def test_group_route_namespace_deep_using_route_values_in_constructor(self):
+        routes = RouteGroup([
+            RouteGroup([
+                Get('/test/1', 'DeepController@show'),
             ], namespace='deep.')
         ], namespace='subdirectory.')
 

--- a/tests/core/test_routes.py
+++ b/tests/core/test_routes.py
@@ -140,6 +140,14 @@ class TestRoutes(unittest.TestCase):
         self.assertEqual(['auth', 'user'], routes[1].list_middleware)
         self.assertEqual(['test', 'test2', 'auth', 'user'], routes[2].list_middleware)
 
+    def test_group_route_namespace_using_route_values_in_constructor(self):
+        routes = RouteGroup([
+            Get('/test/1', 'SubController@show'),
+        ], namespace='subdirectory.')
+
+        self.assertIsInstance(routes, list)
+        self.assertEqual(SubController, routes[0].controller)
+
     def test_group_route_namespace(self):
         routes = RouteGroup([
             Get().route('/test/1', 'SubController@show'),

--- a/tests/core/test_routes.py
+++ b/tests/core/test_routes.py
@@ -2,6 +2,7 @@
 import unittest
 
 from app.http.controllers.subdirectory.SubController import SubController
+from app.http.controllers.subdirectory.deep.DeepController import DeepController
 from src.masonite.app import App
 from src.masonite.exceptions import (InvalidRouteCompileException,
                                      RouteException)
@@ -138,6 +139,24 @@ class TestRoutes(unittest.TestCase):
         self.assertEqual(['another', 'auth', 'user'], routes[0].list_middleware)
         self.assertEqual(['auth', 'user'], routes[1].list_middleware)
         self.assertEqual(['test', 'test2', 'auth', 'user'], routes[2].list_middleware)
+
+    def test_group_route_namespace(self):
+        routes = RouteGroup([
+            Get().route('/test/1', 'SubController@show'),
+        ], namespace='subdirectory.')
+
+        self.assertIsInstance(routes, list)
+        self.assertEqual(SubController, routes[0].controller)
+
+    def test_group_route_namespace_deep(self):
+        routes = RouteGroup([
+            RouteGroup([
+                Get().route('/test/1', 'DeepController@show'),
+            ], namespace='deep.')
+        ], namespace='subdirectory.')
+
+        self.assertIsInstance(routes, list)
+        self.assertEqual(DeepController, routes[0].controller)
 
     def test_group_route_sets_domain(self):
         routes = RouteGroup([

--- a/tests/core/test_routes.py
+++ b/tests/core/test_routes.py
@@ -168,6 +168,16 @@ class TestRoutes(unittest.TestCase):
         self.assertIsInstance(routes, list)
         self.assertEqual(DeepController, routes[0].controller)
 
+    def test_group_route_namespace_deep_no_dots(self):
+        routes = RouteGroup([
+            RouteGroup([
+                Get().route('/test/1', 'DeepController@show'),
+            ], namespace='deep')
+        ], namespace='subdirectory')
+
+        self.assertIsInstance(routes, list)
+        self.assertEqual(DeepController, routes[0].controller)
+
     def test_group_route_sets_domain(self):
         routes = RouteGroup([
             Get().route('/test/1', 'TestController@show'),


### PR DESCRIPTION
This adds the namespace parameter to RouteGroup and fixes #226.

One change I'd note:
Prior to this fix, some process (I'm not sure what) tries to find the controllers for all the routes up front. Because Routes are constructed before RouteGroups, this meant that you would get a bunch of "Cannot find controller" messages up front, then the RouteGroup would adjust the namespace and resolve properly. This was misleading, so I therefore moved the print to when you attempt to use the route. This aligns with when the exception is raised, but may make it more difficult to track down malformed routes since the controllers are not reported as malformed up front. 

Perhaps `craft show:routes` could be adjusted to resolve controllers? 

Alternatively -- I just thought of this -- perhaps the _namespace function could check for self.e after calling find_controller and show the print then. Or perhaps add a flag to find_controller to control whether or not to show the print. This would let it resolve the routes/routegroups and warn about them up front. Any thoughts?

Here are example routes that I used for testing:
```
from masonite.routes import RouteGroup, Get, Post                                
from app.http.controllers.auth.LoginController import LoginController            
                                                                                 
ROUTES = [
    # Auth Login Routes (same as Auth.routes() from craft auth)                                         
    RouteGroup([                                                                 
        Get('/login', 'LoginController@show').name('login'),                         
        Get('/logout', 'LoginController@logout').name('logout'),                     
        Post('/login', 'LoginController@store'),                                     
        Get('/register', 'RegisterController@show').name('register'),                
        Post('/register', 'RegisterController@store'),                               
        Get('/home', 'HomeController@show').name('home'),                            
        Get('/email/verify', 'ConfirmController@verify_show').name('verify'),        
        Get('/email/verify/send', 'ConfirmController@send_verify_email'),            
        Get('/email/verify/@id:signed', 'ConfirmController@confirm_email'),          
        Get('/password', 'PasswordController@forget').name('forgot.password'),       
        Post('/password', 'PasswordController@send'),                                
        Get('/password/@token/reset', 'PasswordController@reset').name('password.reset'),
        Post('/password/@token/reset', 'PasswordController@update'),                 
                                                                                 
        Get('/missing', 'MissingController@show').name('missing'), # Testing a missing controller
    ], namespace='auth.'), # Note the namespace!                                                      
                                                                                 
    # More routes with prefix and namespaces
    RouteGroup([                                                                 
        Get('/login', 'LoginController@show'),             
        Get('/register', 'RegisterController@show').name('register'),
        Get('/loginb', LoginController.show).name('loginb'), # Testing Controller object reference
    ], prefix='/authprefix', name='authorize.', namespace='auth.'),
]
```

URLs to test:
```
/login  - should resolve correctly
/register - should resolve correctly
... all the normal craft auth URLs work
/missing - should fail with an exception and print the cannot find controller message

/authprefix/login - should resolve and show normal login form
/authprefix/register - show resolve and show normal register form
/authprefix/loginb - should also show the login form
```

As the comment shows, when using the (probably rarely used) controller object reference, the namespace is ignored. I figure if you wanted it, you'd provide it in the import. This lets you use a combination of string and object references in the same RouteGroup. (Not sure why you would want to do this or if anyone would.)

I'm a little concerned about the potential for confusion between name (which gets added to named routes) and namespace, but haven't thought of a better solution. If anything, I'd change name since it is generic to name_prefix or something. This would be a breaking changing to existing RouteGroups, though.
