### PR TITLE
Allow SMTP without login

### DIFF
--- a/config/mail.py
+++ b/config/mail.py
@@ -31,6 +31,8 @@ DRIVERS = {
         'port': env('MAIL_PORT', '465'),
         'username': env('MAIL_USERNAME', 'username'),
         'password': env('MAIL_PASSWORD', 'password'),
+        'ssl': env('MAIL_SSL', False),
+        'login': env('MAIL_LOGIN_REQUIRED', True),
     },
     'mailgun': {
         'secret': env('MAILGUN_SECRET', 'key-XX'),

--- a/src/masonite/drivers/mail/MailSmtpDriver.py
+++ b/src/masonite/drivers/mail/MailSmtpDriver.py
@@ -43,7 +43,8 @@ class MailSmtpDriver(BaseMailDriver, MailContract):
             self.smtp = smtplib.SMTP('{0}:{1}'.format(
                 config['host'], config['port']))
 
-        self.smtp.login(config['username'], config['password'])
+        if config.get('login', True):
+            self.smtp.login(config['username'], config['password'])
 
         if self._queue:
             from wsgi import container


### PR DESCRIPTION
As noted in issue #260 this adds support for making the SMTP login optional. If the login entry is missing, it defaults to True - it requires login just like before.