### PR TITLE
Add unit test coverage for shared-stubs

### DIFF
--- a/tests/presets/test_react.py
+++ b/tests/presets/test_react.py
@@ -47,6 +47,7 @@ class TestReact(unittest.TestCase):
         React().ensure_component_directory_exists()
         React().update_bootstrapping()
         self.assertTrue(filecmp.cmp('src/masonite/commands/presets/react-stubs/app.js', 'resources/js/app.js'))
+        self.assertTrue(filecmp.cmp('src/masonite/commands/presets/shared-stubs/bootstrap.js', 'resources/js/bootstrap.js'))
         shutil.rmtree('resources/js')
 
     def test_install(self):

--- a/tests/presets/test_vue.py
+++ b/tests/presets/test_vue.py
@@ -45,6 +45,7 @@ class TestVue(unittest.TestCase):
         Vue().ensure_component_directory_exists()
         Vue().update_bootstrapping()
         self.assertTrue(filecmp.cmp('src/masonite/commands/presets/vue-stubs/app.js', 'resources/js/app.js'))
+        self.assertTrue(filecmp.cmp('src/masonite/commands/presets/shared-stubs/bootstrap.js', 'resources/js/bootstrap.js'))
         shutil.rmtree('resources/js')
 
     def test_install(self):


### PR DESCRIPTION
This adds assertions for the bootstrap.js file that was added in #235 for vue and react presets from the shared-stubs directory.