### PR TITLE
Add missing app.scss for Vue/React presets

### DIFF
--- a/src/masonite/commands/presets/Preset.py
+++ b/src/masonite/commands/presets/Preset.py
@@ -36,3 +36,10 @@ class Preset:
             if os.path.exists(os.path.realpath(filename)):
                 os.remove(filename)
         shutil.rmtree('node_modules', ignore_errors=True)
+
+    def create_scss_file(self):
+        """Create an empty app.scss file"""
+        os.makedirs(os.path.realpath('resources/sass'))
+        with open(os.path.realpath('resources/sass/app.scss'), 'w') as f:
+            f.write('// Add your Sass here')
+

--- a/src/masonite/commands/presets/Preset.py
+++ b/src/masonite/commands/presets/Preset.py
@@ -42,4 +42,3 @@ class Preset:
         os.makedirs(os.path.realpath('resources/sass'))
         with open(os.path.realpath('resources/sass/app.scss'), 'w') as f:
             f.write('// Add your Sass here')
-

--- a/src/masonite/commands/presets/React.py
+++ b/src/masonite/commands/presets/React.py
@@ -18,6 +18,7 @@ class React(Preset):
         self.update_webpack_configuration()
         self.update_bootstrapping()
         self.update_component()
+        self.create_scss_file()
         self.remove_node_modules()
 
     def update_package_array(self, packages={}):

--- a/src/masonite/commands/presets/Vue.py
+++ b/src/masonite/commands/presets/Vue.py
@@ -18,6 +18,7 @@ class Vue(Preset):
         self.update_webpack_configuration()
         self.update_bootstrapping()
         self.update_component()
+        self.create_scss_file()
         self.remove_node_modules()
 
     def update_package_array(self, packages={}):

--- a/tests/presets/test_preset.py
+++ b/tests/presets/test_preset.py
@@ -23,3 +23,8 @@ class TestPreset(unittest.TestCase):
         # Preset().update_packages()
         # TODO: Not sure how to test this just yet
         pass
+
+    def test_create_scss_file(self):
+        Preset().create_scss_file()
+        self.assertTrue(os.path.exists('resources/sass/app.scss'))
+        shutil.rmtree('resources/sass')

--- a/tests/presets/test_react.py
+++ b/tests/presets/test_react.py
@@ -55,6 +55,8 @@ class TestReact(unittest.TestCase):
         self.assertTrue(filecmp.cmp('src/masonite/commands/presets/react-stubs/webpack.mix.js', 'webpack.mix.js'))
         self.assertTrue(filecmp.cmp('src/masonite/commands/presets/react-stubs/Example.js', 'resources/js/components/Example.js'))
         self.assertTrue(filecmp.cmp('src/masonite/commands/presets/react-stubs/app.js', 'resources/js/app.js'))
+        self.assertTrue(os.path.exists('resources/sass/app.scss'))
+        shutil.rmtree('resources/sass')
         shutil.rmtree('resources/js')
         os.remove('webpack.mix.js')
         shutil.copyfile('package.json.save', 'package.json')

--- a/tests/presets/test_react.py
+++ b/tests/presets/test_react.py
@@ -47,6 +47,7 @@ class TestReact(unittest.TestCase):
         React().ensure_component_directory_exists()
         React().update_bootstrapping()
         self.assertTrue(filecmp.cmp('src/masonite/commands/presets/react-stubs/app.js', 'resources/js/app.js'))
+        self.assertTrue(filecmp.cmp('src/masonite/commands/presets/shared-stubs/bootstrap.js', 'resources/js/bootstrap.js'))
         shutil.rmtree('resources/js')
 
     def test_install(self):

--- a/tests/presets/test_vue.py
+++ b/tests/presets/test_vue.py
@@ -53,6 +53,8 @@ class TestVue(unittest.TestCase):
         self.assertTrue(filecmp.cmp('src/masonite/commands/presets/vue-stubs/webpack.mix.js', 'webpack.mix.js'))
         self.assertTrue(filecmp.cmp('src/masonite/commands/presets/vue-stubs/ExampleComponent.vue', 'resources/js/components/ExampleComponent.vue'))
         self.assertTrue(filecmp.cmp('src/masonite/commands/presets/vue-stubs/app.js', 'resources/js/app.js'))
+        self.assertTrue(os.path.exists('resources/sass/app.scss'))
+        shutil.rmtree('resources/sass')
         shutil.rmtree('resources/js')
         os.remove('webpack.mix.js')
         shutil.copyfile('package.json.save', 'package.json')

--- a/tests/presets/test_vue.py
+++ b/tests/presets/test_vue.py
@@ -45,6 +45,7 @@ class TestVue(unittest.TestCase):
         Vue().ensure_component_directory_exists()
         Vue().update_bootstrapping()
         self.assertTrue(filecmp.cmp('src/masonite/commands/presets/vue-stubs/app.js', 'resources/js/app.js'))
+        self.assertTrue(filecmp.cmp('src/masonite/commands/presets/shared-stubs/bootstrap.js', 'resources/js/bootstrap.js'))
         shutil.rmtree('resources/js')
 
     def test_install(self):


### PR DESCRIPTION
This will add an empty app.scss to resources/sass when calling `craft preset vue` or `craft preset react`