### PR TITLE
Feature/297

### DIFF
--- a/src/masonite/helpers/structures.py
+++ b/src/masonite/helpers/structures.py
@@ -80,7 +80,6 @@ class Dot:
             elif isinstance(v, list):
                 for index, val in enumerate(v):
                     items.extend(self.flatten({str(index): val}, new_key, sep=sep).items())
-                print('key', new_key)
             else:
                 items.append((new_key, v))
 

--- a/src/masonite/helpers/structures.py
+++ b/src/masonite/helpers/structures.py
@@ -77,8 +77,13 @@ class Dot:
             if isinstance(v, collections.MutableMapping):
                 items.append((new_key, v))
                 items.extend(self.flatten(v, new_key, sep=sep).items())
+            elif isinstance(v, list):
+                for index, val in enumerate(v):
+                    items.extend(self.flatten({str(index): val}, new_key, sep=sep).items())
+                print('key', new_key)
             else:
                 items.append((new_key, v))
+
         return dict(items)
 
     def locate(self, search_path, default=''):

--- a/src/masonite/request.py
+++ b/src/masonite/request.py
@@ -84,7 +84,7 @@ class Request(Extendable):
             return self.request_variables.get(name)
 
         if '.' in name and isinstance(self.request_variables.get(name.split('.')[0]), dict):
-            return DictDot().dot(name, self.request_variables)
+            return clean_request_input(DictDot().dot(name, self.request_variables, default=default), clean=clean)
 
         elif '.' in name:
             name = dot(name, "{1}[{.}]")

--- a/src/masonite/request.py
+++ b/src/masonite/request.py
@@ -84,9 +84,7 @@ class Request(Extendable):
             return self.request_variables.get(name)
 
         if '.' in name and isinstance(self.request_variables.get(name.split('.')[0]), dict):
-            value = DictDot().dot(name, self.request_variables)
-            if value:
-                return value
+            return DictDot().dot(name, self.request_variables)
 
         elif '.' in name:
             name = dot(name, "{1}[{.}]")

--- a/src/masonite/request.py
+++ b/src/masonite/request.py
@@ -78,6 +78,10 @@ class Request(Extendable):
         Returns:
             string
         """
+        name = str(name)
+        if name.isnumeric():
+            return self.request_variables.get(name)
+
         if '.' in name and isinstance(self.request_variables.get(name.split('.')[0]), dict):
             value = DictDot().dot(name, self.request_variables)
             if value:
@@ -223,6 +227,9 @@ class Request(Extendable):
         # vv = variables
         if isinstance(variables, str):
             variables = query_parse(variables)
+
+        if isinstance(variables, list):
+            variables = {str(i): v for i, v in enumerate(variables)}
 
         try:
             self.request_variables = {}

--- a/src/masonite/request.py
+++ b/src/masonite/request.py
@@ -57,6 +57,7 @@ class Request(Extendable):
         self._status = None
         self.request_variables = {}
         self._test_user = False
+        self.raw_input = None
 
         if environ:
             self.load_environ(environ)
@@ -150,6 +151,10 @@ class Request(Extendable):
         Returns:
             dict
         """
+
+        if isinstance(self.raw_input, list):
+            return self.raw_input
+
         if not internal_variables:
             without_internals = {}
             for key, value in self.request_variables.items():
@@ -229,6 +234,7 @@ class Request(Extendable):
             variables = query_parse(variables)
 
         if isinstance(variables, list):
+            self.raw_input = variables
             variables = {str(i): v for i, v in enumerate(variables)}
 
         try:

--- a/tests/core/test_requests.py
+++ b/tests/core/test_requests.py
@@ -446,7 +446,22 @@ class TestRequest(unittest.TestCase):
             "description": "test only"
         })
 
-        self.assertEqual(request.input('response'), None)
+    def test_can_get_nully_value_with_dictdot(self):
+        app = App()
+        app.bind('Request', self.request)
+        request = app.make('Request').load_app(app)
+
+        request._set_standardized_request_variables({
+            "gateway": "RENDIMENTO",
+            "request": {
+                "user": "data",
+                "age": None,
+            },
+            "response": None,
+            "description": "test only"
+        })
+
+        self.assertEqual(request.input('request.age'), None)
 
     def test_can_get_list_as_root_payload(self):
         app = App()

--- a/tests/core/test_requests.py
+++ b/tests/core/test_requests.py
@@ -448,6 +448,30 @@ class TestRequest(unittest.TestCase):
 
         self.assertEqual(request.input('response'), None)
 
+    def test_can_get_list_as_root_payload(self):
+        app = App()
+        app.bind('Request', self.request)
+        request = app.make('Request').load_app(app)
+
+        request._set_standardized_request_variables([{"key": "val"}, {"item2": "val2"}])
+
+        self.assertEqual(request.input(0)['key'], 'val')
+        self.assertEqual(request.input('0')['key'], 'val')
+        self.assertEqual(request.input(2), None)
+
+    def test_can_get_list_as_root_payload_as_dot_notation(self):
+        app = App()
+        app.bind('Request', self.request)
+        request = app.make('Request').load_app(app)
+
+        request._set_standardized_request_variables([{"key": "val"}, {"item2": "val2", "inner": {"value": "innervalue"}}, {"item3": [1,2]}])
+
+        self.assertEqual(request.input('0.key'), 'val')
+        self.assertEqual(request.input('1.item2'), 'val2')
+        self.assertEqual(request.input('1.inner.value'), 'innervalue')
+        self.assertEqual(request.input('2.item3.0'), 1)
+        self.assertEqual(request.input('3.item3'), False)
+
     def test_request_gets_correct_header(self):
         app = App()
         app.bind('Request', self.request)

--- a/tests/core/test_requests.py
+++ b/tests/core/test_requests.py
@@ -459,6 +459,15 @@ class TestRequest(unittest.TestCase):
         self.assertEqual(request.input('0')['key'], 'val')
         self.assertEqual(request.input(2), None)
 
+    def test_can_get_list_as_root_payload_getting_all(self):
+        app = App()
+        app.bind('Request', self.request)
+        request = app.make('Request').load_app(app)
+
+        request._set_standardized_request_variables([{"key": "val"}, {"item2": "val2"}])
+
+        self.assertIsInstance(request.all(), list)
+
     def test_can_get_list_as_root_payload_as_dot_notation(self):
         app = App()
         app.bind('Request', self.request)

--- a/tests/core/test_requests.py
+++ b/tests/core/test_requests.py
@@ -467,6 +467,7 @@ class TestRequest(unittest.TestCase):
         request._set_standardized_request_variables([{"key": "val"}, {"item2": "val2"}])
 
         self.assertIsInstance(request.all(), list)
+        self.assertEqual(request.all()[0]['key'], 'val')
 
     def test_can_get_list_as_root_payload_as_dot_notation(self):
         app = App()

--- a/tests/core/test_requests.py
+++ b/tests/core/test_requests.py
@@ -463,6 +463,7 @@ class TestRequest(unittest.TestCase):
 
         self.assertEqual(request.input('request.age'), None)
         self.assertEqual(request.input('request.age', default=1), None)
+        self.assertEqual(request.input('request.salary', default=1), 1)
 
     def test_can_get_list_as_root_payload(self):
         app = App()

--- a/tests/core/test_requests.py
+++ b/tests/core/test_requests.py
@@ -462,6 +462,7 @@ class TestRequest(unittest.TestCase):
         })
 
         self.assertEqual(request.input('request.age'), None)
+        self.assertEqual(request.input('request.age', default=1), None)
 
     def test_can_get_list_as_root_payload(self):
         app = App()

--- a/tests/helpers/test_dot_notation.py
+++ b/tests/helpers/test_dot_notation.py
@@ -22,8 +22,10 @@ class TestDot(unittest.TestCase):
         self.assertEqual(DictDot().dot('key.test', {'key': {'test': 'value'}}), 'value')
         self.assertEqual(DictDot().dot('key.test.layer', {'key': {'test': {'layer': 'value'}}}), 'value')
         self.assertEqual(DictDot().dot('key.none', {'key': {'test': {'layer': 'value'}}}), None)
-        self.assertEqual(DictDot().dot('key', {'key': {'test': {'layer': 'value'}}}), {'test': {'layer': 'value'}})
+        self.assertEqual(DictDot().dot('key.test', {'key': {'test': {'layer': 'value'}}}), {'test': {'layer': 'value'}})
         self.assertEqual(DictDot().dot('key.test.none', {'key': 'value'}), None)
+        self.assertEqual(DictDot().flatten({'key': [1,2]}), {'key.0': 1, 'key.1': 2})
+        self.assertEqual(DictDot().dot('key.0', {'key': [1,2]}), 1)
 
     def test_dict_dot_asterisk(self):
         payload = {

--- a/tests/helpers/test_dot_notation.py
+++ b/tests/helpers/test_dot_notation.py
@@ -22,7 +22,7 @@ class TestDot(unittest.TestCase):
         self.assertEqual(DictDot().dot('key.test', {'key': {'test': 'value'}}), 'value')
         self.assertEqual(DictDot().dot('key.test.layer', {'key': {'test': {'layer': 'value'}}}), 'value')
         self.assertEqual(DictDot().dot('key.none', {'key': {'test': {'layer': 'value'}}}), None)
-        self.assertEqual(DictDot().dot('key.test', {'key': {'test': {'layer': 'value'}}}), {'test': {'layer': 'value'}})
+        self.assertEqual(DictDot().dot('key', {'key': {'test': {'layer': 'value'}}}), {'test': {'layer': 'value'}})
         self.assertEqual(DictDot().dot('key.test.none', {'key': 'value'}), None)
         self.assertEqual(DictDot().flatten({'key': [1,2]}), {'key.0': 1, 'key.1': 2})
         self.assertEqual(DictDot().dot('key.0', {'key': [1,2]}), 1)


### PR DESCRIPTION
* Fixes issue with null values not returning correctly when using dot notation
* Adds improvements for dot notation when working with lists (able to retrieve values with list indexes `key.0.value.1`)
* Fixes issue with getting a list as a payload throwing an exception
* `requst.all()` will Now returns a list if a list was passed into it

Closes #297 