### PR TITLE
'Mail - mail_from and to_addresses

### DIFF
--- a/src/masonite/drivers/mail/BaseMailDriver.py
+++ b/src/masonite/drivers/mail/BaseMailDriver.py
@@ -1,11 +1,15 @@
 """Base mail driver module."""
 
 import copy
+import re
 
 from ...app import App
 from ...helpers import config
 from ...response import Responsable
 from .. import BaseDriver
+
+
+MAIL_FROM_RE = re.compile(r'(?:"?([^"]*)"?\s)?(?:<?(.+@[^>]+)>?)')
 
 
 class BaseMailDriver(BaseDriver, Responsable):
@@ -20,12 +24,21 @@ class BaseMailDriver(BaseDriver, Responsable):
         """
         self.config = config('mail')
         self.app = app
-        self.to_address = None
-        self.from_address = self.config.FROM
+        self.to_addresses = []
         self.message_subject = 'Subject'
         self.message_reply_to = None
         self.message_body = None
+        self.from_name = self.config.FROM['name']
+        self.from_address = self.config.FROM['address']
         self._queue = False
+
+    @property
+    def mail_from_header(self):
+        return '"{0}" <{1}>'.format(self.from_name, self.from_address)
+
+    @property
+    def mail_to_header(self):
+        return ','.join(self.to_addresses)
 
     def to(self, user_email):
         """Set the user email address who you want to send mail to.
@@ -39,7 +52,10 @@ class BaseMailDriver(BaseDriver, Responsable):
         if callable(user_email):
             user_email = user_email.email
 
-        self.to_address = user_email
+        if isinstance(user_email, (list, tuple)):
+            self.to_addresses = user_email
+        else:
+            self.to_addresses = [user_email]
         return self
 
     def queue(self):
@@ -67,16 +83,28 @@ class BaseMailDriver(BaseDriver, Responsable):
         self.message_body = view.render(template_name, dictionary).rendered_template
         return self
 
-    def send_from(self, address):
+    def send_from(self, address, name=None):
         """Set the from address of who the sender should be.
 
         Arguments:
-            address {string} -- A name used as the From field in an email.
+            address {string} -- A email address used as the From field in an email.
+                                "John S" <john@example.com>
+                                John S <john@example.com>
+                                john@example.com
+            name {string} -- A name used as the From field in an email.
 
         Returns:
             self
         """
-        self.from_address = address
+        match = MAIL_FROM_RE.match(address)
+        if not match:
+            raise ValueError('Invalid address specified')
+
+        match_name, match_address = match.groups()
+        self.from_address = match_address
+        if name is None and match_name:
+            self.from_name = match_name
+
         return self
 
     def mailable(self, mailable):

--- a/src/masonite/drivers/mail/MailLogDriver.py
+++ b/src/masonite/drivers/mail/MailLogDriver.py
@@ -47,9 +47,8 @@ class MailLogDriver(BaseMailDriver, MailContract):
 
         self.logger.info('***************************************')
 
-        self.logger.info('To: {}'.format(self.to_address))
-        self.logger.info('From: {0} <{1}>'.format(
-            self.config.FROM['name'], self.config.FROM['address']))
+        self.logger.info('To: {}'.format(self.mail_to_header))
+        self.logger.info('From: {}'.format(self.mail_from_header))
         self.logger.info('Subject: {}'.format(self.message_subject))
         self.logger.info('Reply-To: {}'.format(self.message_reply_to))
         self.logger.info('Message: ')

--- a/src/masonite/drivers/mail/MailMailgunDriver.py
+++ b/src/masonite/drivers/mail/MailMailgunDriver.py
@@ -44,8 +44,8 @@ class MailMailgunDriver(BaseMailDriver, MailContract):
             "https://api.mailgun.net/v3/{0}/messages".format(domain),
             auth=("api", secret),
             data={
-                "from": "{0} <{1}>".format(self.config.FROM['name'], self.from_address),
-                "to": [self.to_address],
+                "from": self.mail_from_header,
+                "to": self.to_addresses,
                 "subject": self.message_subject,
                 "h:Reply-To": self.message_reply_to,
                 "html": message})

--- a/src/masonite/drivers/mail/MailSmtpDriver.py
+++ b/src/masonite/drivers/mail/MailSmtpDriver.py
@@ -30,9 +30,8 @@ class MailSmtpDriver(BaseMailDriver, MailContract):
         message_contents = MIMEText(message_contents, 'html')
 
         message['Subject'] = self.message_subject
-        message['From'] = '{0} <{1}>'.format(
-            self.config.FROM['name'], self.config.FROM['address'])
-        message['To'] = self.to_address
+        message['From'] = self.mail_from_header
+        message['To'] = self.mail_to_header
         message['Reply-To'] = self.message_reply_to
         message.attach(message_contents)
 
@@ -51,12 +50,11 @@ class MailSmtpDriver(BaseMailDriver, MailContract):
             from ... import Queue
             container.make(Queue).push(
                 self._send_mail,
-                args=(self.config.FROM['name'], self.to_address, message.as_string())
+                args=(self.mail_from_header, self.to_addresses, message.as_string())
             )
             return
 
-        self._send_mail(self.config.FROM['name'],
-                self.to_address, message.as_string())
+        self._send_mail(self.mail_from_header, self.to_addresses, message.as_string())
 
     def _send_mail(self, *args):
         """Wrapper around sending mail so it can also be used for queues."""

--- a/src/masonite/drivers/mail/MailTerminalDriver.py
+++ b/src/masonite/drivers/mail/MailTerminalDriver.py
@@ -34,9 +34,8 @@ class MailTerminalDriver(BaseMailDriver, MailContract):
 
         self.logger.info('***************************************')
 
-        self.logger.info('To: {}'.format(self.to_address))
-        self.logger.info('From: {0} <{1}>'.format(
-            self.config.FROM['name'], self.config.FROM['address']))
+        self.logger.info('To: {}'.format(self.mail_to_header))
+        self.logger.info('From: {}'.format(self.mail_from_header))
         self.logger.info('Subject: {}'.format(self.message_subject))
         self.logger.info('Reply-To: {}'.format(self.message_reply_to))
         self.logger.info('Message: ')

--- a/src/masonite/drivers/mail/Mailable.py
+++ b/src/masonite/drivers/mail/Mailable.py
@@ -17,7 +17,7 @@ class Mailable:
         self._reply_to = reply_to
         return self
 
-    def send_from(self, send_from):
+    def send_from(self, send_from, from_name):
         self._from = send_from
         return self
 

--- a/src/masonite/drivers/mail/Mailable.py
+++ b/src/masonite/drivers/mail/Mailable.py
@@ -17,7 +17,7 @@ class Mailable:
         self._reply_to = reply_to
         return self
 
-    def send_from(self, send_from, from_name):
+    def send_from(self, send_from):
         self._from = send_from
         return self
 

--- a/tests/core/test_mail_log_drivers.py
+++ b/tests/core/test_mail_log_drivers.py
@@ -43,7 +43,7 @@ class TestMailLogDrivers(unittest.TestCase):
         user = UserMock
         user.email = 'test@email.com'
 
-        self.assertEqual(MailManager(self.app).driver('log').to(user).to_address, 'test@email.com')
+        self.assertEqual(MailManager(self.app).driver('log').to(user).to_addresses, ['test@email.com'])
 
     def test_log_mail_renders_template(self):
 
@@ -52,9 +52,9 @@ class TestMailLogDrivers(unittest.TestCase):
 
     def test_terminal_driver(self):
         user = UserMock
-        user.email = 'test@email.com'
+        user.email = ['test@email.com']
 
-        self.assertEqual(MailManager(self.app).driver('terminal').to(user).to_address, 'test@email.com')
+        self.assertEqual(MailManager(self.app).driver('terminal').to(user).to_addresses, ['test@email.com'])
 
     def test_terminal_mail_renders_template(self):
 

--- a/tests/core/test_mail_smtp_driver.py
+++ b/tests/core/test_mail_smtp_driver.py
@@ -32,7 +32,7 @@ class TestSMTPDriver(unittest.TestCase):
         user = UserMock
         user.email = 'test@email.com'
 
-        self.assertEqual(MailManager(self.app).driver('smtp').to(user).to_address, 'test@email.com')
+        self.assertEqual(MailManager(self.app).driver('smtp').to(user).to_addresses, ['test@email.com'])
         self.assertEqual(MailManager(self.app).driver('smtp').reply_to('reply_to@email.com').message_reply_to , 'reply_to@email.com')
 
     def test_mail_renders_template(self):
@@ -52,7 +52,7 @@ class TestMailable(TestCase):
 
     def test_works(self):
         mailable = MailManager(self.container).driver('smtp').mailable(ForgotPasswordMailable())
-        self.assertEqual(mailable.to_address, 'idmann509@gmail.com')
+        self.assertEqual(mailable.to_addresses, ['idmann509@gmail.com'])
         self.assertEqual(mailable.from_address, 'admin@test.com')
         self.assertEqual(mailable.message_subject, 'Forgot Password')
         self.assertEqual(mailable.message_body, 'testing email')


### PR DESCRIPTION
- Make mail.send_from more consistent. Allow setting the mail from address including the display name.
	Supported using:
		`mail.send_from('john.smith@example.com')`
		`mail.send_from('John Smith <john.smith@example.com>')`
		`mail.send_from('john.smith@example.com', 'John Smith')`

- renamed `to_address` to `to_addresses` and is now held as a list of addresses
	Supported:
		`mail.to('john@example.com')`
		`mail.to(['john@example.com'])`
		`mail.to(['john@example.com', 'another@example.com'])`