### PR TITLE
Fixed raw_input to reset for each request

### DIFF
--- a/src/masonite/request.py
+++ b/src/masonite/request.py
@@ -245,6 +245,7 @@ class Request(Extendable):
         self.method = environ['REQUEST_METHOD']
         self.path = environ['PATH_INFO']
         self.request_variables = {}
+        self.raw_input = None
 
         if 'QUERY_STRING' in environ and environ['QUERY_STRING']:
             self.query_params = parse_qs(environ['QUERY_STRING'])
@@ -269,8 +270,8 @@ class Request(Extendable):
         if isinstance(variables, str):
             variables = query_parse(variables)
 
+        self.raw_input = variables
         if isinstance(variables, list):
-            self.raw_input = variables
             variables = {str(i): v for i, v in enumerate(variables)}
 
         try:

--- a/src/masonite/testing/__init__.py
+++ b/src/masonite/testing/__init__.py
@@ -1,4 +1,4 @@
 from .TestCase import TestCase
 from .MockRoute import MockRoute
-from .generate_wsgi import generate_wsgi
+from .generate_wsgi import generate_wsgi, MockWsgiInput
 from .create_container import create_container

--- a/src/masonite/testing/generate_wsgi.py
+++ b/src/masonite/testing/generate_wsgi.py
@@ -2,6 +2,14 @@
 import io
 
 
+class MockWsgiInput():
+    def __init__(self, data):
+        self.data = data
+
+    def read(self, _):
+        return self.data
+
+
 def generate_wsgi():
     return {
         'wsgi.version': (1, 0),

--- a/tests/core/test_extends.py
+++ b/tests/core/test_extends.py
@@ -1,5 +1,5 @@
 from src.masonite.app import App
-from src.masonite.testing import generate_wsgi
+from src.masonite.testing import generate_wsgi, MockWsgiInput
 from src.masonite.routes import Route
 from src.masonite.request import Request
 
@@ -27,14 +27,6 @@ class ExtendClass2:
 
     def get_another_path2(self):
         return self.path
-
-
-class MockWsgiInput():
-    def __init__(self, data):
-        self.data = data
-
-    def read(self, _):
-        return self.data
 
 
 def get_third_path(self):


### PR DESCRIPTION
If you have a request coming in as a list and then as a dict, `request.all()` currently returns the old list from the previous request. This PR fixes this issue.