### PR TITLE
Add multiple arg support to dd()

### DIFF
--- a/src/masonite/snippets/exceptions/dump.html
+++ b/src/masonite/snippets/exceptions/dump.html
@@ -35,11 +35,22 @@
 
 <body>
     <div class="container-fluid">
+        {% if objs|count > 1 %}
+        <div class="row">Showing {{ objs|count }} objects:</div>
+        {% endif %}
+        {% for o in objs %}
+            {% set obj = o.obj %}
+            {% set members = o.members %}
+            {% set properties = o.properties %}
         <div class="row">
             <span class="obj">{{ obj.__class__.__name__}}</span> {{ obj }}
         </div>
         {% for key, property in properties %}
             {% include 'obj_loop.html' %}
+        {% endfor %}
+            {% if not loop.last %}
+            <hr>
+            {% endif %}
         {% endfor %}
     </div>
 


### PR DESCRIPTION
This adds support for passing multiple objects to dd() and having it show all the results. The existing single argument form still works.

I kept the members property since it was in the original exception_handler, but unless I'm missing something it isn't used.

I made some edits to the output. It includes a header showing the number of objects if you dump more than one. I also added separators between them so it is easier to tell where the output for one ends and the next one begins.