### PR TITLE
Added request methods to get info of the request

### DIFF
--- a/src/masonite/request.py
+++ b/src/masonite/request.py
@@ -11,7 +11,7 @@ of this class.
 import re
 from cgi import MiniFieldStorage
 from http import cookies
-from urllib.parse import parse_qs
+from urllib.parse import parse_qs, quote
 
 import tldextract
 from cryptography.fernet import InvalidToken
@@ -339,6 +339,94 @@ class Request(Extendable):
             bool
         """
         return all((arg in self.request_variables) for arg in args)
+
+    def scheme(self):
+        """Get the current request url scheme
+
+        Returns:
+            string -- the scheme used for the request (http|https)
+        """
+        return self.environ['wsgi.url_scheme']
+
+    def host(self):
+        """Get the server's hostname for the current request.
+
+        Returns:
+            string -- the hostname
+        """
+        host = self.environ.get('HTTP_HOST')
+        if not host:
+            host = self.environ['SERVER_NAME']
+        return host.split(':', 1)[0]
+
+    def port(self):
+        """Get the server's port number for the current request.
+
+        Returns:
+            string -- the server's port number.
+        """
+        return self.environ['SERVER_PORT']
+
+    def full_path(self, quoted=True):
+        """Get the path part of the current request url. (including the application path).
+
+        Args:
+            quoted {bool} -- whether to escape special chars (default: {True}).
+
+        Returns:
+            string -- the path of the url
+        """
+        url = self.environ.get('SCRIPT_NAME', '') + self.environ.get('PATH_INFO', '')
+        if quoted:
+            url = quote(url)
+        return url
+
+    def url(self, include_standard_port=False):
+        """Get the url of the current request including the scheme://host:port/path.
+
+        Args:
+            include_standard_port {bool} -- whether to include the port
+                when the request uses the standard http(s) port (default: {False}).
+
+        Returns:
+            string -- the requested url.
+        """
+        scheme = self.scheme()
+        host = self.host()
+        port = self.port()
+        path = self.full_path()
+        if include_standard_port or (scheme == 'https' and port != '443') or (scheme == 'http' and port != '80'):
+            port_part = ':{}'.format(port)
+        else:
+            port_part = ''
+        return '{}://{}{}{}'.format(scheme, host, port_part, path)
+
+    def full_url(self, include_standard_port=False):
+        """Get the full url including query string of the current request.
+            example:
+             scheme://host:port/path?query-string
+
+        Args:
+            include_standard_port {bool} -- whether to include the port
+                when the request uses the standard http(s) port (default: {False}).
+
+        Returns:
+            string -- The full request url
+        """
+        url = self.url(include_standard_port=include_standard_port)
+        query_string = self.query_string()
+        if query_string:
+            return '{}?{}'.format(url, query_string)
+        else:
+            return url
+
+    def query_string(self):
+        """Get the raw query string of the current request url.
+
+        Returns:
+            string -- The query-string of the request
+        """
+        return self.environ.get('QUERY_STRING', '')
 
     def status(self, status):
         """Set the HTTP status code.

--- a/tests/core/test_requests.py
+++ b/tests/core/test_requests.py
@@ -28,7 +28,7 @@ class TestRequest(unittest.TestCase):
 
     def setUp(self):
         self.app = App()
-        self.request = Request(wsgi_request).key(
+        self.request = Request(wsgi_request.copy()).key(
             'NCTpkICMlTXie5te9nJniMj9aVbPM6lsjeq5iDZ0dqY=').load_app(self.app)
         self.app.bind('Request', self.request)
         self.response = Response(self.app)
@@ -764,3 +764,95 @@ class TestRequest(unittest.TestCase):
         self.assertEqual(self.request.input('key.user'), '1')
         self.assertEqual(self.request.input('key.nothing'), False)
         self.assertEqual(self.request.input('key.nothing', default='test'), 'test')
+
+    def test_request_scheme(self):
+        self.request.environ['wsgi.url_scheme'] = 'http'
+        self.assertEqual(self.request.scheme(), 'http')
+        self.request.environ['wsgi.url_scheme'] = 'https'
+        self.assertEqual(self.request.scheme(), 'https')
+
+    def test_request_host(self):
+        self.request.environ.update({'HTTP_HOST': 'www.masonite.com:80', 'SERVER_NAME': '127.0.0.1'})
+        self.assertEqual(self.request.host(), 'www.masonite.com')
+
+        self.request.environ.update({'HTTP_HOST': 'www.masonite.com:8000'})
+        self.assertEqual(self.request.host(), 'www.masonite.com')
+
+        self.request.environ.update({'HTTP_HOST': ''})
+        self.assertEqual(self.request.host(), '127.0.0.1')
+
+    def test_request_port(self):
+        self.request.environ.update({'SERVER_PORT': '443'})
+        self.assertEqual(self.request.port(), '443')
+
+        self.request.environ.update({'SERVER_PORT': '8000'})
+        self.assertEqual(self.request.port(), '8000')
+
+    def test_request_path(self):
+        def update_environ(**kwargs):
+            environ = self.request.environ
+            environ.update(kwargs)
+            self.request.load_environ(environ)
+
+        update_environ(**{'SCRIPT_NAME': '', 'PATH_INFO': '/root/masonite'})
+        self.assertEqual(self.request.full_path(), '/root/masonite')
+        self.assertEqual(self.request.path, '/root/masonite')
+
+        update_environ(**{'SCRIPT_NAME': '/application', 'PATH_INFO': '/root/masonite'})
+        self.assertEqual(self.request.full_path(), '/application/root/masonite')
+        self.assertEqual(self.request.path, '/root/masonite')
+
+        update_environ(**{'SCRIPT_NAME': '/application', 'PATH_INFO': '/'})
+        self.assertEqual(self.request.full_path(), '/application/')
+        self.assertEqual(self.request.path, '/')
+
+        update_environ(**{'SCRIPT_NAME': '/application', 'PATH_INFO': '/masonite/hello world/'})
+        self.assertEqual(self.request.full_path(), '/application/masonite/hello%20world/')
+        self.assertEqual(self.request.full_path(quoted=False), '/application/masonite/hello world/')
+
+    def test_request_query_string(self):
+        self.assertEqual(self.request.query_string(), 'application=Masonite')
+
+    def test_url(self):
+        self.request.environ.update({
+            'wsgi.url_scheme': 'https',
+            'HTTP_HOST': 'www.masonite.com:443',
+            'SERVER_PORT': '443',
+            'SERVER_NAME': '127.0.0.1',
+            'SCRIPT_NAME': '/application',
+            'PATH_INFO': '/root/masonite is the best',
+            'QUERY_STRING': 'Hello World',
+        })
+        self.assertEqual(self.request.url(), 'https://www.masonite.com/application/root/masonite%20is%20the%20best')
+        self.assertEqual(self.request.url(include_standard_port=True),
+                         'https://www.masonite.com:443/application/root/masonite%20is%20the%20best')
+
+        self.request.environ.update({
+            'HTTP_HOST': 'www.masonite.com:80',
+            'SERVER_PORT': '80',
+        })
+        self.assertEqual(self.request.url(), 'https://www.masonite.com:80/application/root/masonite%20is%20the%20best')
+
+        self.request.environ['wsgi.url_scheme'] = 'http'
+        self.assertEqual(self.request.url(), 'http://www.masonite.com/application/root/masonite%20is%20the%20best')
+
+        del self.request.environ['HTTP_HOST']
+        self.assertEqual(self.request.url(), 'http://127.0.0.1/application/root/masonite%20is%20the%20best')
+
+        self.request.environ['wsgi.url_scheme'] = 'https'
+        self.assertEqual(self.request.url(), 'https://127.0.0.1:80/application/root/masonite%20is%20the%20best')
+
+    def test_full_url(self):
+        self.request.environ.update({
+            'wsgi.url_scheme': 'https',
+            'HTTP_HOST': 'www.masonite.com:443',
+            'SERVER_PORT': '443',
+            'SERVER_NAME': '127.0.0.1',
+            'SCRIPT_NAME': '/application',
+            'PATH_INFO': '/root/masonite is the best',
+            'QUERY_STRING': 'q=Hello&var=val',
+        })
+        self.assertEqual(
+            self.request.full_url(),
+            'https://www.masonite.com/application/root/masonite%20is%20the%20best?q=Hello&var=val'
+        )


### PR DESCRIPTION
`request.scheme()` http/https
`request.host()` server host
`request.port()` server port
`request.url()` scheme://host:port/path
`request.full_path()` path part of the url
`request.full_url()`  scheme://host:port/path?query-string
`request.query_string()` query-string part