### PR TITLE
Correct the module name

### DIFF
--- a/src/masonite/middleware/GuardMiddleware.py
+++ b/src/masonite/middleware/GuardMiddleware.py
@@ -1,4 +1,4 @@
-"""CSRF Middleware."""
+"""Guard Middleware."""
 
 from ..auth import Auth
 from ..helpers import config


### PR DESCRIPTION
I noticed the that Guard middleware had the wrong name, so I created this silly pull request to fix it.