### PR TITLE
Route controllers can now be set without a method in routes.

### DIFF
--- a/src/masonite/routes.py
+++ b/src/masonite/routes.py
@@ -213,7 +213,7 @@ class BaseHttpRoute:
             self.controller = getattr(module, get_controller)
 
             # Set the controller method on class. This is a string
-            self.controller_method = mod[1]
+            self.controller_method = mod[1] if len(mod) == 2 else '__call__'
         except ImportError as e:
             import sys
             import traceback


### PR DESCRIPTION
Ref. discussion in #questions on Slack.

I made a small bypass to allow defining route controllers without a method by performing the following change in https://github.com/MasoniteFramework/masonite/blob/cb6d0d8333c648436425b6fc40f165af36c6a41e/src/masonite/routes.py#L216
```python
self.controller_method = mod[1] if len(mod) == 2 else '__call__'
```

This allows for routes to be defined more similar to Laravel, like this: `GET('/', 'WelcomeController').name('welcome'),` instead of the current: `GET('/', 'WelcomeController@show').name('welcome'),`.

Corresponding controller.
```python
class WelcomeController(Controller):
    def __call__(self, request: Request):
        return {"message": "Welcome."}
```

I know this is not the correct way use `__call__`, but would you be interested in implementing a correct implementation of this in the official library? It would be similar to `__invoke` in PHP / Laravel.