### PR TITLE
Fix/370: Update NPM dependencies

### DIFF
--- a/src/masonite/commands/presets/Vue3.py
+++ b/src/masonite/commands/presets/Vue3.py
@@ -30,11 +30,11 @@ class Vue3(Preset):
         for package in ["@babel/preset-react", "react", "react-dom"]:
             packages.pop(package, None)
 
-        packages["vue"] = "^3.0.0"
-        packages["@vue/compiler-sfc"] = "^3.0.0"
-        packages["laravel-mix"] = "^6.0.0-beta.7"
-        packages["vue-loader"] = "^16.0.0-beta.8"
-        packages["postcss"] = "^8.1.1"
+        packages["vue"] = "^3.0.4"
+        packages["@vue/compiler-sfc"] = "^3.0.4"
+        packages["laravel-mix"] = "^6.0.5"
+        packages["vue-loader"] = "^16.1.2"
+        packages["postcss"] = "^8.2.1"
 
         return packages
 

--- a/src/masonite/commands/presets/Vue3.py
+++ b/src/masonite/commands/presets/Vue3.py
@@ -32,9 +32,7 @@ class Vue3(Preset):
 
         packages["vue"] = "^3.0.4"
         packages["@vue/compiler-sfc"] = "^3.0.4"
-        packages["laravel-mix"] = "^6.0.5"
         packages["vue-loader"] = "^16.1.2"
-        packages["postcss"] = "^8.2.1"
 
         return packages
 

--- a/tests/presets/test_vue3.py
+++ b/tests/presets/test_vue3.py
@@ -10,11 +10,9 @@ class TestVue(unittest.TestCase):
 
     def test_update_package_array(self):
         expected_packages = {
-            'vue': '^3.0.0',
-            '@vue/compiler-sfc': '^3.0.0',
-            'laravel-mix': '^6.0.0-beta.7',
-            'vue-loader': '^16.0.0-beta.8',
-            'postcss': '^8.1.1'
+            'vue': '^3.0.4',
+            '@vue/compiler-sfc': '^3.0.4',
+            'vue-loader': '^16.1.2',
         }
         # Verify it works with no existing packages
         self.assertDictEqual(expected_packages, Vue3().update_package_array())


### PR DESCRIPTION
Implements part of #370 to upgrade Vue 3 preset dependencies.
The other part is in cookie-cutter repo https://github.com/MasoniteFramework/cookie-cutter/pull/7