### PR TITLE
craft new can select cookie-cutter version according to masonite version

### DIFF
--- a/src/masonite/__init__.py
+++ b/src/masonite/__init__.py
@@ -13,4 +13,5 @@ from .__version__ import (
     __author__,
     __author_email__,
     __licence__,
+    __cookie_cutter_version__
 )

--- a/src/masonite/__version__.py
+++ b/src/masonite/__version__.py
@@ -6,3 +6,5 @@ __version__ = "3.0.1"
 __author__ = "Joseph Mancuso"
 __author_email__ = "joe@masoniteproject.com"
 __licence__ = "MIT"
+
+__cookie_cutter_version__ = "3.0"

--- a/src/masonite/commands/NewCommand.py
+++ b/src/masonite/commands/NewCommand.py
@@ -65,8 +65,7 @@ class NewCommand(Command):
             self.set_api_provider_url_for_repo(provider, repo)
 
             # find cookie-cutter version to use when doing 'craft new' only
-            if repo == "MasoniteFramework/cookie-cutter" and provider == "github" \
-                and branch == "False" and version == "False":
+            if repo == "MasoniteFramework/cookie-cutter" and provider == "github" and branch == "False" and version == "False":
                 branch = __cookie_cutter_version__
 
             if branch != "False":

--- a/src/masonite/commands/NewCommand.py
+++ b/src/masonite/commands/NewCommand.py
@@ -11,6 +11,7 @@ from ..exceptions import (
     ProjectProviderHttpError,
     ProjectTargetNotEmpty,
 )
+from .. import __cookie_cutter_version__
 
 
 class NewCommand(Command):
@@ -62,6 +63,11 @@ class NewCommand(Command):
                 )
 
             self.set_api_provider_url_for_repo(provider, repo)
+
+            # find cookie-cutter version to use when doing 'craft new' only
+            if repo == "MasoniteFramework/cookie-cutter" and provider == "github" \
+                and branch == "False" and version == "False":
+                branch = __cookie_cutter_version__
 
             if branch != "False":
                 branch_data = self.get_branch_provider_data(provider, branch)

--- a/src/masonite/helpers/routes.py
+++ b/src/masonite/helpers/routes.py
@@ -25,6 +25,7 @@ def flatten_routes(routes):
 
     return route_collection
 
+
 def compile_route_to_regex(route):
     """Compile a route to regex.
 


### PR DESCRIPTION
Closes #387.

@josephmancuso ready for review 👍 

To be noted :
- If you want to change name of version holder and its location, no problem
- Either with bumpversion or commitizen the cookie-cutter will be able to be also bumped.
- I guess we will need to merge this branch in 2.X too
- I was wondering if craft new should pull cookie-cutter specific branch or cookie-cutter specific tag, both are possible for now I updated code to use branch, I can quickly change to use tag if you prefer.
- Also we won't release a cookie-cutter version for each patch updates of masonite, so we don't want that `__cookie_cutter_version__` bumped for each patch updates. maybe the code should only use the `major` number of the e.g. version 3.2.4 et 3.5.0 will both use `3.0` branch. But this prevent to have a different cookie-cutter version for minor versions of masonite.

🤔  don't know right now