### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/masonite/helpers/structures.py
+++ b/src/masonite/helpers/structures.py
@@ -2,7 +2,7 @@
 
 import inspect
 import pydoc
-from collections import MutableMapping
+from collections.abc import MutableMapping
 
 from masoniteorm.collection import Collection as collect
 


### PR DESCRIPTION
Fixes #393.

Very small fix to remove deprecated warning shown when running tests