### PR TITLE
Add possibility to mock existing and future services

### DIFF
--- a/src/masonite/drivers/mail/BaseMailDriver.py
+++ b/src/masonite/drivers/mail/BaseMailDriver.py
@@ -7,7 +7,7 @@ from ...app import App
 from ...helpers import config, deprecated
 from ...response import Responsable
 from .. import BaseDriver
-from ...mock import Mockable, StaticallyCallable
+from ...mock import Mockable
 
 MAIL_FROM_RE = re.compile(r'(?:"?([^"]*)"?\s)?(?:<?(.+@[^>]+)>?)')
 

--- a/src/masonite/drivers/mail/BaseMailDriver.py
+++ b/src/masonite/drivers/mail/BaseMailDriver.py
@@ -3,18 +3,19 @@
 import copy
 import re
 
-
 from ...app import App
 from ...helpers import config, deprecated
 from ...response import Responsable
 from .. import BaseDriver
-
+from ...mock import Mockable, StaticallyCallable
 
 MAIL_FROM_RE = re.compile(r'(?:"?([^"]*)"?\s)?(?:<?(.+@[^>]+)>?)')
 
 
-class BaseMailDriver(BaseDriver, Responsable):
+class BaseMailDriver(BaseDriver, Responsable, Mockable):
     """Base mail driver class. This class is inherited by all mail drivers."""
+
+    __service__ = "Mail"
 
     def __init__(self, app: App):
         """Base mail driver constructor.
@@ -34,6 +35,10 @@ class BaseMailDriver(BaseDriver, Responsable):
         self.html_content = None
         self.text_content = None
         self._message = None
+
+    def get_mock_class():
+        from ...testing.mocks.MockMail import MockMail
+        return MockMail
 
     def _get_message_for_send_deprecated(self, message_contents):
         """Helper method for backwards compatibility to generate a message from .send()

--- a/src/masonite/drivers/mail/BaseMailDriver.py
+++ b/src/masonite/drivers/mail/BaseMailDriver.py
@@ -35,6 +35,9 @@ class BaseMailDriver(BaseDriver, Responsable, Mockable):
         self.html_content = None
         self.text_content = None
         self._message = None
+        self._template_name = None
+        self._template_context = None
+        self._mailable = None
 
     def get_mock_class():
         from ...testing.mocks.MockMail import MockMail
@@ -148,6 +151,8 @@ class BaseMailDriver(BaseDriver, Responsable, Mockable):
         """
         view = copy.copy(self.app.make("ViewClass"))
         content = view.render(template_name, dictionary).rendered_template
+        self._template_name = template_name
+        self._template_context = dictionary
         if mimetype == "html":
             self.html(content)
         else:
@@ -195,6 +200,7 @@ class BaseMailDriver(BaseDriver, Responsable, Mockable):
             .template(mailable.template, mailable.variables)
             .reply_to(mailable._reply_to)
         )
+        self._mailable = mailable
         return self
 
     def subject(self, subject):

--- a/src/masonite/drivers/queue/BaseQueueDriver.py
+++ b/src/masonite/drivers/queue/BaseQueueDriver.py
@@ -6,9 +6,17 @@ import pendulum
 
 from ...drivers import BaseDriver
 from ...helpers import HasColoredCommands
+from ...mock import Mockable
 
 
-class BaseQueueDriver(BaseDriver, HasColoredCommands):
+class BaseQueueDriver(BaseDriver, HasColoredCommands, Mockable):
+
+    __service__ = "Queue"
+
+    def get_mock_class():
+        from ...testing.mocks.MockQueue import MockQueue
+        return MockQueue
+
     def add_to_failed_queue_table(self, payload, channel=None, driver="amqp"):
         from config.database import DB
         from config import queue

--- a/src/masonite/mock.py
+++ b/src/masonite/mock.py
@@ -4,8 +4,14 @@ from abc import abstractmethod
 class StaticallyCallable(type):
     def __getattr__(self, attribute, *args, **kwargs):
         from wsgi import container
+        import pdb; pdb.set_trace()
         instance = container.make(self.__service__)
         return getattr(instance, attribute)
+
+
+# class MyMixin(metaclass=StaticallyCallable):
+#     # __metaclass__ = StaticallyCallable
+#     pass
 
 
 class Mockable():
@@ -20,11 +26,12 @@ class Mockable():
 
     __service__ = ""
 
-    # def __getattr__(self, attribute, *args, **kwargs):
-    #     from wsgi import container
-    #     import pdb ; pdb.set_trace()
-    #     instance = container.make(self.__service__)
-    #     return getattr(instance, attribute)
+    @classmethod
+    def __getattr__(cls, attribute, *args, **kwargs):
+        import pdb ; pdb.set_trace()
+        from wsgi import container
+        instance = container.make(cls.__service__)
+        return getattr(instance, attribute)
 
     @abstractmethod
     def get_mock_class():

--- a/src/masonite/mock.py
+++ b/src/masonite/mock.py
@@ -33,9 +33,9 @@ class Mockable():
         )
 
     @classmethod
-    def fake(cls):
+    def fake(cls, **kwargs):
         from wsgi import container
-        mock_instance = cls.get_mock_class()(container)
+        mock_instance = cls.get_mock_class()(container, **kwargs)
         container.bind(cls.__service__, mock_instance)
         return mock_instance
 

--- a/src/masonite/mock.py
+++ b/src/masonite/mock.py
@@ -1,0 +1,50 @@
+from abc import abstractmethod
+
+
+class StaticallyCallable(type):
+    def __getattr__(self, attribute, *args, **kwargs):
+        from wsgi import container
+        instance = container.make(self.__service__)
+        return getattr(instance, attribute)
+
+
+class Mockable():
+    """A mixin to define a service as mockable, to be able to quickly test
+    the service with its fakeable implementation.
+        Service.fake()
+        # tests...
+        Service.restore()
+    This can be done inside a unit tests or defined globally in setUp() / tearDown() methods
+    of a test case.
+    """
+
+    __service__ = ""
+
+    # def __getattr__(self, attribute, *args, **kwargs):
+    #     from wsgi import container
+    #     import pdb ; pdb.set_trace()
+    #     instance = container.make(self.__service__)
+    #     return getattr(instance, attribute)
+
+    @abstractmethod
+    def get_mock_class():
+        raise NotImplementedError(
+            "get_mock_class() method must be implemented for a mockable service."
+        )
+
+    @classmethod
+    def fake(cls):
+        from wsgi import container
+        mock_instance = cls.get_mock_class()(container)
+        container.bind(cls.__service__, mock_instance)
+        return mock_instance
+
+    @classmethod
+    def restore(cls):
+        from wsgi import container
+        try:
+            original_instance = cls(container)
+        except TypeError:
+            original_instance = cls()
+        container.bind(cls.__service__, original_instance)
+        return original_instance

--- a/src/masonite/mock.py
+++ b/src/masonite/mock.py
@@ -4,17 +4,12 @@ from abc import abstractmethod
 class StaticallyCallable(type):
     def __getattr__(self, attribute, *args, **kwargs):
         from wsgi import container
-        import pdb; pdb.set_trace()
+
         instance = container.make(self.__service__)
         return getattr(instance, attribute)
 
 
-# class MyMixin(metaclass=StaticallyCallable):
-#     # __metaclass__ = StaticallyCallable
-#     pass
-
-
-class Mockable():
+class Mockable:
     """A mixin to define a service as mockable, to be able to quickly test
     the service with its fakeable implementation.
         Service.fake()
@@ -28,8 +23,8 @@ class Mockable():
 
     @classmethod
     def __getattr__(cls, attribute, *args, **kwargs):
-        import pdb ; pdb.set_trace()
         from wsgi import container
+
         instance = container.make(cls.__service__)
         return getattr(instance, attribute)
 
@@ -42,6 +37,7 @@ class Mockable():
     @classmethod
     def fake(cls, **kwargs):
         from wsgi import container
+
         mock_instance = cls.get_mock_class()(container, **kwargs)
         container.bind(cls.__service__, mock_instance)
         return mock_instance
@@ -49,6 +45,7 @@ class Mockable():
     @classmethod
     def restore(cls):
         from wsgi import container
+
         try:
             original_instance = cls(container)
         except TypeError:

--- a/src/masonite/mock.py
+++ b/src/masonite/mock.py
@@ -21,13 +21,6 @@ class Mockable:
 
     __service__ = ""
 
-    @classmethod
-    def __getattr__(cls, attribute, *args, **kwargs):
-        from wsgi import container
-
-        instance = container.make(cls.__service__)
-        return getattr(instance, attribute)
-
     @abstractmethod
     def get_mock_class():
         raise NotImplementedError(

--- a/src/masonite/testing/mocks/MockMail.py
+++ b/src/masonite/testing/mocks/MockMail.py
@@ -1,3 +1,4 @@
+from ...drivers.mail.Mailable import Mailable
 from ...drivers.mail.BaseMailDriver import BaseMailDriver
 
 
@@ -8,17 +9,37 @@ class MockMail(BaseMailDriver):
         self.mails = []
 
     def send(self, message=None):
-        self.mails.append(message)
+        data = {
+            "message": message or self.message_body,
+            "subject": self.message_subject,
+            "text": self.text_content,
+            "html": self.html_content,
+            "to": self.to_addresses,
+            "reply_to": self.message_reply_to,
+            "from_name": self.from_name,
+            "from_address": self.from_address,
+            "template": self._template_name,
+            "is_mailable": bool(self._mailable),
+            "mailable": self._mailable,
+            "context": self._template_context
+        }
+        self.mails.append(data)
 
     def driver(self, driver):
         return self
 
-    def assertCount(self, count):
-        import pdb ; pdb.set_trace()
+    def assertCountAll(self, count):
         assert len(self.mails) == count
 
     def assertNothingSent(self):
         assert not self.mails
+
+    def assertSent(self, mailable_class, count=1):
+        # if not issubclass(mailable_class, Mailable):
+        #     raise ValueError("assertSent accepts only Mailable class")
+        sent_mails = [mail['mailable'] for mail in self.mails if (mail["mailable"] and mail["mailable"].__class__ == mailable_class)]
+        import pdb ; pdb.set_trace()
+        assert count == len(sent_mails)
 
     def assertSentTo(self, recipients, mailable):
         pass

--- a/src/masonite/testing/mocks/MockMail.py
+++ b/src/masonite/testing/mocks/MockMail.py
@@ -49,7 +49,10 @@ class MailWithAsserts():
             MailableWithAsserts.patch(self.mailable.__class__)
             self.context = self.mailable.variables
             self.view = self.mailable.template
-            self.to = self.mailable._to
+            to_addresses = self.mailable._to
+            if not isinstance(to_addresses, list):
+                to_addresses = [to_addresses]
+            self.to = to_addresses
             self.sent_from = self.mailable._from
             self.reply_to = self.mailable._reply_to
             self.subject = self.mailable._subject

--- a/src/masonite/testing/mocks/MockMail.py
+++ b/src/masonite/testing/mocks/MockMail.py
@@ -1,8 +1,7 @@
 from ...drivers.mail.BaseMailDriver import BaseMailDriver
 
 
-class MailableWithAsserts():
-
+class MailableWithAsserts:
     def hasTo(self, to):
         assert to in self._to
         return self
@@ -37,15 +36,14 @@ class MailableWithAsserts():
     def patch(cls, target):
         for k in cls.__dict__:
             obj = getattr(cls, k)
-            if not k.startswith('_') and callable(obj):
+            if not k.startswith("_") and callable(obj):
                 setattr(target, k, obj)
 
-class MailWithAsserts():
 
+class MailWithAsserts:
     def __init__(self, obj, mailable=None):
         self.mailable = obj._mailable
         if self.mailable:
-            # TODO: do this ?
             MailableWithAsserts.patch(self.mailable.__class__)
             self.context = self.mailable.variables
             self.view = self.mailable.template
@@ -60,7 +58,6 @@ class MailWithAsserts():
             self.context = obj._template_context
             self.view = obj._template_name
             self.to = obj.to_addresses
-            # TODO: check from name and address ? for mailable ?
             self.sent_from = obj.from_name
             self.reply_to = obj.message_reply_to
             self.subject = obj.message_subject
@@ -114,7 +111,6 @@ class MailWithAsserts():
 
 
 class MockMail(BaseMailDriver):
-
     def __init__(self, container):
         super().__init__(container)
         self.mails = []
@@ -149,12 +145,16 @@ class MockMail(BaseMailDriver):
             recipients = [recipients]
         sent_mails = []
         for recipient in recipients:
-            sent_mails += [mail for mail in self.mails if mail._isMailable(mailable_class) and mail.hasTo(recipient)]
+            sent_mails += [
+                mail
+                for mail in self.mails
+                if mail._isMailable(mailable_class) and mail.hasTo(recipient)
+            ]
         assert len(sent_mails) == len(recipients)
         return sent_mails
 
     def assertNotSentTo(self, recipients, mailable_class):
-        # TODO: should this fail for every of the recipient ?
+        # @all: should this fail for every of the recipient ?
         sent_mails = self.assertSentTo(recipients, mailable_class)
         assert len(sent_mails) != len(recipients)
 

--- a/src/masonite/testing/mocks/MockMail.py
+++ b/src/masonite/testing/mocks/MockMail.py
@@ -1,0 +1,27 @@
+from ...drivers.mail.BaseMailDriver import BaseMailDriver
+
+
+class MockMail(BaseMailDriver):
+
+    def __init__(self, container):
+        super().__init__(container)
+        self.mails = []
+
+    def send(self, message=None):
+        self.mails.append(message)
+
+    def driver(self, driver):
+        return self
+
+    def assertCount(self, count):
+        import pdb ; pdb.set_trace()
+        assert len(self.mails) == count
+
+    def assertNothingSent(self):
+        assert not self.mails
+
+    def assertSentTo(self, recipients, mailable):
+        pass
+
+    def assertNotSentTo(self, recipients, mailable):
+        pass

--- a/src/masonite/testing/mocks/MockMail.py
+++ b/src/masonite/testing/mocks/MockMail.py
@@ -2,6 +2,46 @@ from ...drivers.mail.Mailable import Mailable
 from ...drivers.mail.BaseMailDriver import BaseMailDriver
 
 
+class MailableAssertions():
+
+    def hasTo(self, to):
+        assert to in self._to
+        return self
+
+    def hasSubject(self, subject):
+        assert subject == self._subject
+        return self
+
+    def hasReplyTo(self, reply_to):
+        assert reply_to in self._reply_to
+        return self
+
+    def isSentFrom(self, sent_from):
+        assert sent_from == self._from
+        return self
+
+    def hasView(self, template):
+        assert template == self.template
+        return self
+
+    def hasInContext(self, key, val=None):
+        assert key in self.variables
+        if val:
+            assert self.variables[key] == val
+        return self
+
+    def hasContext(self, context):
+        assert context == self.variables
+        return self
+
+    @classmethod
+    def patch(cls, target):
+        for k in cls.__dict__:
+            obj = getattr(cls, k)
+            if not k.startswith('_') and callable(obj):
+                setattr(target, k, obj)
+
+
 class MockMail(BaseMailDriver):
 
     def __init__(self, container):
@@ -9,6 +49,9 @@ class MockMail(BaseMailDriver):
         self.mails = []
 
     def send(self, message=None):
+        if self._mailable:
+            # attach mailable tests helpers
+            MailableAssertions.patch(self._mailable.__class__)
         data = {
             "message": message or self.message_body,
             "subject": self.message_subject,
@@ -34,12 +77,13 @@ class MockMail(BaseMailDriver):
     def assertNothingSent(self):
         assert not self.mails
 
-    def assertSent(self, mailable_class, count=1):
+    def assertSent(self, mailable_class, test_method=None, count=1):
         # if not issubclass(mailable_class, Mailable):
         #     raise ValueError("assertSent accepts only Mailable class")
         sent_mails = [mail['mailable'] for mail in self.mails if (mail["mailable"] and mail["mailable"].__class__ == mailable_class)]
-        import pdb ; pdb.set_trace()
         assert count == len(sent_mails)
+        if test_method:
+            assert test_method(sent_mails[0])
 
     def assertSentTo(self, recipients, mailable):
         pass

--- a/src/masonite/testing/mocks/MockMail.py
+++ b/src/masonite/testing/mocks/MockMail.py
@@ -1,8 +1,7 @@
-from ...drivers.mail.Mailable import Mailable
 from ...drivers.mail.BaseMailDriver import BaseMailDriver
 
 
-class MailableAssertions():
+class MailableWithAsserts():
 
     def hasTo(self, to):
         assert to in self._to
@@ -47,7 +46,7 @@ class MailWithAsserts():
         self.mailable = obj._mailable
         if self.mailable:
             # TODO: do this ?
-            MailableAssertions.patch(self.mailable.__class__)
+            MailableWithAsserts.patch(self.mailable.__class__)
             self.context = self.mailable.variables
             self.view = self.mailable.template
             self.to = self.mailable._to
@@ -121,7 +120,7 @@ class MockMail(BaseMailDriver):
         """Mock sending email."""
         if self._mailable:
             # attach mailable tests helpers
-            MailableAssertions.patch(self._mailable.__class__)
+            MailableWithAsserts.patch(self._mailable.__class__)
         mail = MailWithAsserts(self)
         self.mails.append(mail)
 

--- a/src/masonite/testing/mocks/MockQueue.py
+++ b/src/masonite/testing/mocks/MockQueue.py
@@ -78,6 +78,16 @@ class MockQueue(BaseQueueDriver):
             job_channel = matching_jobs[0]["channel"]
             test_method(job, job_args, job_channel)
 
+    def assertPushedWithArgs(self, job, args, count=1):
+        matching_jobs = []
+        for jobs_in_queue in self.queued_jobs.values():
+            matching_jobs += jobs_in_queue.get(str(job.__name__), [])
+        assert len(matching_jobs) == count
+        # check if args are corresponding
+        for job in matching_jobs:
+            job_args = job[0]["args"]
+            assert job_args == args
+
     def assertPushedOn(self, job, queue, count=1):
         # TODO: display easy error message if no jobs pushed on channel
         assert len(self.queued_jobs[queue][str(job.__name__)]) == count

--- a/src/masonite/testing/mocks/MockQueue.py
+++ b/src/masonite/testing/mocks/MockQueue.py
@@ -4,15 +4,20 @@ import inspect
 
 from ...drivers.queue.BaseQueueDriver import BaseQueueDriver
 
+
 def makehash():
     return collections.defaultdict(makehash)
 
+
 def deep_get(dictionary, keys, default=None):
-    return reduce(lambda d, key: d.get(key, default) if isinstance(d, dict) else default, keys.split("."), dictionary)
+    return reduce(
+        lambda d, key: d.get(key, default) if isinstance(d, dict) else default,
+        keys.split("."),
+        dictionary,
+    )
 
 
 class MockQueue(BaseQueueDriver):
-
     def __init__(self, container=None, immediate=False):
         self.container = container
         self._run = immediate
@@ -32,19 +37,13 @@ class MockQueue(BaseQueueDriver):
                 job_name = job.__class__.__name__
 
             queue = options.get("channel", None) or options.get("queue", None) or "all"
-            data = {
-                "job": job,
-                "queue": queue,
-                "args": args,
-                "options": options
-            }
+            data = {"job": job, "queue": queue, "args": args, "options": options}
             path = f"{queue}.{str(job_name)}"
             try:
                 # run task immediately if required
                 if self._run:
                     getattr(job, callback)(*args, **kwargs)
-            except:
-                print("Job failed !")
+            except:  # noqa: E722
                 self._store_fail(data, path)
             else:
                 self._store_success(data, path)

--- a/src/masonite/testing/mocks/MockQueue.py
+++ b/src/masonite/testing/mocks/MockQueue.py
@@ -78,19 +78,22 @@ class MockQueue(BaseQueueDriver):
             job_channel = matching_jobs[0]["channel"]
             test_method(job, job_args, job_channel)
 
+    def assertNotPushed(self, job, count=1):
+        matching_jobs = []
+        for jobs_in_queue in self.queued_jobs.values():
+            matching_jobs += jobs_in_queue.get(str(job.__name__), [])
+        assert len(matching_jobs) != count
+
     def assertPushedWithArgs(self, job, args, count=1):
         matching_jobs = []
         for jobs_in_queue in self.queued_jobs.values():
             matching_jobs += jobs_in_queue.get(str(job.__name__), [])
         assert len(matching_jobs) == count
         # check if args are corresponding
-        for job in matching_jobs:
-            job_args = job[0]["args"]
+        for j in matching_jobs:
+            job_args = j["args"]
             assert job_args == args
 
     def assertPushedOn(self, job, queue, count=1):
-        # TODO: display easy error message if no jobs pushed on channel
+        """Assert that a job has been pushed onto a given {queue}, {count} times."""
         assert len(self.queued_jobs[queue][str(job.__name__)]) == count
-
-    def assertPushedWithArgs(self, job, count=1):
-        pass

--- a/src/masonite/testing/mocks/MockQueue.py
+++ b/src/masonite/testing/mocks/MockQueue.py
@@ -1,0 +1,86 @@
+import collections
+from functools import reduce
+import inspect
+
+from ...drivers.queue.BaseQueueDriver import BaseQueueDriver
+
+def makehash():
+    return collections.defaultdict(makehash)
+
+def deep_get(dictionary, keys, default=None):
+    return reduce(lambda d, key: d.get(key, default) if isinstance(d, dict) else default, keys.split("."), dictionary)
+
+
+class MockQueue(BaseQueueDriver):
+
+    def __init__(self, container=None):
+        self.container = container
+        self.queued_jobs = makehash()
+        self.failed_jobs = makehash()
+
+    def push(self, *objects, args=(), kwargs={}, **options):
+
+        callback = options.get("callback", "handle")
+
+        for job in objects:
+            # transform job to be queued in an instance
+            if inspect.isclass(job):
+                job, job_name = self.container.resolve(job), job.__name__
+            else:
+                job_name = job.__class__.__name__
+
+            queue = options.get("channel", None) or options.get("queue", None) or "all"
+            data = {
+                "job": job,
+                "queue": queue,
+                "args": args,
+                "options": options
+            }
+            path = f"{queue}.{str(job_name)}"
+            # execute to see if would pass
+            try:
+                getattr(job, callback)(*args, **kwargs)
+            except:
+                print("Job failed !")
+                self._store_fail(data, path)
+            else:
+                self._store_success(data, path)
+
+    def _store_fail(self, data, path):
+        jobs = deep_get(self.failed_jobs, path)
+        if jobs:
+            jobs.append(data)
+        else:
+            self.failed_jobs[path.split(".")[0]][path.split(".")[1]] = [data]
+
+    def _store_success(self, data, path):
+        jobs = deep_get(self.queued_jobs, path)
+        if jobs:
+            jobs.append(data)
+        else:
+            self.queued_jobs[path.split(".")[0]][path.split(".")[1]] = [data]
+
+    def driver(self, driver):
+        return self
+
+    def assertNothingPushed(self):
+        return not self.queued_jobs
+
+    def assertPushed(self, job, test_method=None, count=1):
+        matching_jobs = []
+        for jobs_in_queue in self.queued_jobs.values():
+            matching_jobs += jobs_in_queue.get(str(job.__name__), [])
+        assert len(matching_jobs) == count
+        # check if first job pushed pass the test
+        if test_method and count > 0:
+            job = matching_jobs[0]["job"]
+            job_args = matching_jobs[0]["args"]
+            job_channel = matching_jobs[0]["channel"]
+            test_method(job, job_args, job_channel)
+
+    def assertPushedOn(self, job, queue, count=1):
+        # TODO: display easy error message if no jobs pushed on channel
+        assert len(self.queued_jobs[queue][str(job.__name__)]) == count
+
+    def assertPushedWithArgs(self, job, count=1):
+        pass

--- a/tests/core/test_responsable.py
+++ b/tests/core/test_responsable.py
@@ -3,12 +3,9 @@ from src.masonite.routes import Get
 
 
 class TestResponsable(TestCase):
-
     def setUp(self):
         super().setUp()
-        self.routes(only=[
-            Get('/test/mail', 'TestController@mail')
-        ])
+        self.routes(only=[Get("/test/mail", "TestController@mail")])
 
     def test_mail_can_respond(self):
-        self.assertTrue(self.get('/test/mail').contains('mail'))
+        self.assertTrue(self.get("/test/mail").contains("mail"))

--- a/tests/queues/test_drivers.py
+++ b/tests/queues/test_drivers.py
@@ -17,6 +17,7 @@ class Job(Queueable):
         print('sending from job handled')
         return 'test'
 
+
 class FailJob(Queueable):
 
     def handle(self):

--- a/tests/testing/test_mail_tests.py
+++ b/tests/testing/test_mail_tests.py
@@ -1,6 +1,16 @@
+from masonite.drivers.mail.Mailable import Mailable
 from tests.core.test_mail_log_drivers import UserMock
 from src.masonite.testing import TestCase
 from src.masonite.drivers.mail.BaseMailDriver import BaseMailDriver as Mail
+
+class TestMailable(Mailable):
+    def build(self):
+        return (self
+            .to('idmann509@gmail.com')
+            .send_from('admin@test.com')
+            .view('emails.test')
+            .reply_to('customer@email.com')
+            .subject('Forgot Password'))
 
 
 class TestUnitTest(TestCase):
@@ -15,7 +25,7 @@ class TestUnitTest(TestCase):
 
     def test_mocking_mailgun(self):
         self.mail.driver('mailgun').to('user@example.com').html('<div>Hello</div>').send()
-        self.mail.assertCount(1)
+        self.mail.assertCountAll(1)
 
     def test_mocking_log(self):
         user = UserMock
@@ -23,5 +33,9 @@ class TestUnitTest(TestCase):
         self.mail.assertNothingSent()
         self.mail.driver('log').to(user).reply_to('reply-to@email.com').send('Masonite')
         self.mail.driver('log').to(user).reply_to('reply-to@email.com').send('Masonite')
-        self.mail.driver('log').to(user).reply_to('reply-to@email.com').send('Masonite')
-        self.mail.assertCount(3)
+        self.mail.assertCountAll(2)
+
+    def test_mailable(self):
+        self.mail.driver('smtp').mailable(TestMailable()).send()
+        self.mail.driver('smtp').mailable(TestMailable()).send()
+        self.mail.assertSent(TestMailable, 2)

--- a/tests/testing/test_mail_tests.py
+++ b/tests/testing/test_mail_tests.py
@@ -3,6 +3,7 @@ from tests.core.test_mail_log_drivers import UserMock
 from src.masonite.testing import TestCase
 from src.masonite.drivers.mail.BaseMailDriver import BaseMailDriver as Mail
 
+
 class TestMailable(Mailable):
     def build(self):
         return (self
@@ -53,3 +54,18 @@ class TestUnitTest(TestCase):
                 .hasInContext('user', 'Sam') \
                 .hasContext({"user": "Sam"}) \
         )
+
+    def test_assert_sent_to(self):
+        pass
+
+    def test_assert_email_content_unified(self):
+        self.mail.driver('mailgun').to('user@example.com').html('<div>Hello</div>').send()
+        self.mail.assertLast() \
+            .hasTo('user@example.com') \
+            .seeIn('<div>Hello</div>')
+
+        self.mail.driver('smtp').mailable(TestMailable()).send()
+        self.mail.assertLast() \
+            .hasTo('idmann509@gmail.com') \
+            .hasView('emails.test') \
+            .seeIn('testing email')

--- a/tests/testing/test_mail_tests.py
+++ b/tests/testing/test_mail_tests.py
@@ -8,7 +8,7 @@ class TestMailable(Mailable):
         return (self
             .to('idmann509@gmail.com')
             .send_from('admin@test.com')
-            .view('emails.test')
+            .view('emails.test', {"user": "Sam"})
             .reply_to('customer@email.com')
             .subject('Forgot Password'))
 
@@ -38,4 +38,18 @@ class TestUnitTest(TestCase):
     def test_mailable(self):
         self.mail.driver('smtp').mailable(TestMailable()).send()
         self.mail.driver('smtp').mailable(TestMailable()).send()
-        self.mail.assertSent(TestMailable, 2)
+        self.mail.assertSent(TestMailable, count=2)
+
+    def test_mailable_with_custom_assertions(self):
+        self.mail.driver('smtp').mailable(TestMailable()).send()
+        self.mail.assertSent(
+            TestMailable,
+            lambda mailable: mailable.hasSubject("Forgot Password") \
+                .hasTo('idmann509@gmail.com') \
+                .hasReplyTo('customer@email.com') \
+                .isSentFrom('admin@test.com') \
+                .hasView('emails.test') \
+                .hasInContext('user') \
+                .hasInContext('user', 'Sam') \
+                .hasContext({"user": "Sam"}) \
+        )

--- a/tests/testing/test_mail_tests.py
+++ b/tests/testing/test_mail_tests.py
@@ -1,0 +1,27 @@
+from tests.core.test_mail_log_drivers import UserMock
+from src.masonite.testing import TestCase
+from src.masonite.drivers.mail.BaseMailDriver import BaseMailDriver as Mail
+
+
+class TestUnitTest(TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.mail = Mail.fake()
+
+    def tearDown(self):
+        super().tearDown()
+        self.mail = Mail.restore()
+
+    def test_mocking_mailgun(self):
+        self.mail.driver('mailgun').to('user@example.com').html('<div>Hello</div>').send()
+        self.mail.assertCount(1)
+
+    def test_mocking_log(self):
+        user = UserMock
+        user.email = 'test@email.com'
+        self.mail.assertNothingSent()
+        self.mail.driver('log').to(user).reply_to('reply-to@email.com').send('Masonite')
+        self.mail.driver('log').to(user).reply_to('reply-to@email.com').send('Masonite')
+        self.mail.driver('log').to(user).reply_to('reply-to@email.com').send('Masonite')
+        self.mail.assertCount(3)

--- a/tests/testing/test_mail_tests.py
+++ b/tests/testing/test_mail_tests.py
@@ -6,16 +6,16 @@ from src.masonite.drivers.mail.BaseMailDriver import BaseMailDriver as Mail
 
 class TestMailable(Mailable):
     def build(self):
-        return (self
-            .to('idmann509@gmail.com')
-            .send_from('admin@test.com')
-            .view('emails.test', {"user": "Sam"})
-            .reply_to('customer@email.com')
-            .subject('Forgot Password'))
+        return (
+            self.to("idmann509@gmail.com")
+            .send_from("admin@test.com")
+            .view("emails.test", {"user": "Sam"})
+            .reply_to("customer@email.com")
+            .subject("Forgot Password")
+        )
 
 
 class TestMockMail(TestCase):
-
     def setUp(self):
         super().setUp()
         self.mail = Mail.fake()
@@ -25,56 +25,54 @@ class TestMockMail(TestCase):
         self.mail = Mail.restore()
 
     def test_mocking_mailgun(self):
-        self.mail.driver('mailgun').to('user@example.com').html('<div>Hello</div>').send()
+        self.mail.driver("mailgun").to("user@example.com").html(
+            "<div>Hello</div>"
+        ).send()
         self.mail.assertCountAll(1)
 
     def test_mocking_log(self):
         user = UserMock
-        user.email = 'test@email.com'
+        user.email = "test@email.com"
         self.mail.assertNothingSent()
-        self.mail.driver('log').to(user).reply_to('reply-to@email.com').send('Masonite')
-        self.mail.driver('log').to(user).reply_to('reply-to@email.com').send('Masonite')
+        self.mail.driver("log").to(user).reply_to("reply-to@email.com").send("Masonite")
+        self.mail.driver("log").to(user).reply_to("reply-to@email.com").send("Masonite")
         self.mail.assertCountAll(2)
 
     def test_mailable(self):
-        self.mail.driver('smtp').mailable(TestMailable()).send()
-        self.mail.driver('smtp').mailable(TestMailable()).send()
+        self.mail.driver("smtp").mailable(TestMailable()).send()
+        self.mail.driver("smtp").mailable(TestMailable()).send()
         self.mail.assertSent(TestMailable, count=2)
 
     def test_mailable_with_custom_assertions(self):
-        self.mail.driver('smtp').mailable(TestMailable()).send()
+        self.mail.driver("smtp").mailable(TestMailable()).send()
         self.mail.assertSent(
             TestMailable,
-            lambda mailable: mailable.hasSubject("Forgot Password") \
-                .hasTo('idmann509@gmail.com') \
-                .hasReplyTo('customer@email.com') \
-                .isSentFrom('admin@test.com') \
-                .hasView('emails.test') \
-                .hasInContext('user') \
-                .hasInContext('user', 'Sam') \
-                .hasContext({"user": "Sam"}) \
+            lambda mailable: mailable.hasSubject("Forgot Password")
+            .hasTo("idmann509@gmail.com")
+            .hasReplyTo("customer@email.com")
+            .isSentFrom("admin@test.com")
+            .hasView("emails.test")
+            .hasInContext("user")
+            .hasInContext("user", "Sam")
+            .hasContext({"user": "Sam"}),
         )
 
     def test_assert_sent_to(self):
         user = UserMock
-        user.email = 'test@email.com'
-        self.mail.driver('log').to(user).reply_to('reply-to@email.com').send('Masonite')
+        user.email = "test@email.com"
+        self.mail.driver("log").to(user).reply_to("reply-to@email.com").send("Masonite")
         self.mail.assertLast().hasTo(user.email)
 
-        self.mail.driver('smtp').mailable(TestMailable()).send()
-        self.mail.assertSentTo('idmann509@gmail.com', TestMailable)
+        self.mail.driver("smtp").mailable(TestMailable()).send()
+        self.mail.assertSentTo("idmann509@gmail.com", TestMailable)
 
     def test_assert_email_content_unified(self):
-        self.mail.driver('mailgun').to('user@example.com').html('<div>Hello</div>').send()
-        self.mail.assertLast() \
-            .hasTo('user@example.com') \
-            .seeIn('<div>Hello</div>')
+        self.mail.driver("mailgun").to("user@example.com").html(
+            "<div>Hello</div>"
+        ).send()
+        self.mail.assertLast().hasTo("user@example.com").seeIn("<div>Hello</div>")
 
-        self.mail.driver('smtp').mailable(TestMailable()).send()
-        self.mail.assertLast() \
-            .hasTo('idmann509@gmail.com') \
-            .hasView('emails.test') \
-            .seeIn('testing email')
-
-    def test_static(self):
-        Mail.assertUnknown("arg")
+        self.mail.driver("smtp").mailable(TestMailable()).send()
+        self.mail.assertLast().hasTo("idmann509@gmail.com").hasView(
+            "emails.test"
+        ).seeIn("testing email")

--- a/tests/testing/test_mail_tests.py
+++ b/tests/testing/test_mail_tests.py
@@ -14,7 +14,7 @@ class TestMailable(Mailable):
             .subject('Forgot Password'))
 
 
-class TestUnitTest(TestCase):
+class TestMockMail(TestCase):
 
     def setUp(self):
         super().setUp()
@@ -56,7 +56,13 @@ class TestUnitTest(TestCase):
         )
 
     def test_assert_sent_to(self):
-        pass
+        user = UserMock
+        user.email = 'test@email.com'
+        self.mail.driver('log').to(user).reply_to('reply-to@email.com').send('Masonite')
+        self.mail.assertLast().hasTo(user.email)
+
+        self.mail.driver('smtp').mailable(TestMailable()).send()
+        self.mail.assertSentTo('idmann509@gmail.com', TestMailable)
 
     def test_assert_email_content_unified(self):
         self.mail.driver('mailgun').to('user@example.com').html('<div>Hello</div>').send()
@@ -69,3 +75,6 @@ class TestUnitTest(TestCase):
             .hasTo('idmann509@gmail.com') \
             .hasView('emails.test') \
             .seeIn('testing email')
+
+    def test_static(self):
+        Mail.assertUnknown("arg")

--- a/tests/testing/test_queue_tests.py
+++ b/tests/testing/test_queue_tests.py
@@ -1,0 +1,51 @@
+from tests.queues.test_drivers import Job, FailJob
+from src.masonite.testing import TestCase
+from src.masonite.drivers.queue.BaseQueueDriver import BaseQueueDriver as Queue
+from src.masonite.queues.Queueable import Queueable
+
+
+class JobWithArgs(Queueable):
+
+    def handle(self, arg1=None):
+        print('sending from job handled', arg1)
+        return 'test'
+
+
+class TestMockQueues(TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.queue = Queue.fake()
+
+    def tearDown(self):
+        super().tearDown()
+        self.queue = Queue.restore()
+
+    def test_mock_push(self):
+        self.queue.assertNothingPushed()
+        self.queue.driver("database").push(Job)
+        self.queue.driver("database").push(Job)
+        self.queue.driver("database").push(Job, channel="test")
+        self.queue.assertPushed(Job, count=3)
+
+    def test_mock_push_on_channel(self):
+        self.queue.assertNothingPushed()
+        self.queue.driver("database").push(Job, channel="high")
+        self.queue.assertPushedOn(Job, "high")
+
+    def test_mock_with_failing_jobs(self):
+        self.queue.driver("database").push(FailJob)
+        self.queue.assertNothingPushed()
+        self.queue.driver("database").push(FailJob, channel="low")
+        self.queue.assertNothingPushed()
+
+    def test_assert_push_two_jobs_in_same_line(self):
+        self.queue.assertNothingPushed()
+        self.queue.driver("database").push(Job, JobWithArgs)
+        self.queue.assertPushed(Job)
+        self.queue.assertPushed(JobWithArgs)
+
+    def test_assert_push_job_with_args(self):
+        self.queue.assertNothingPushed()
+        self.queue.driver("database").push(JobWithArgs, args=(4,))
+        self.queue.assertPushed(JobWithArgs)

--- a/tests/testing/test_queue_tests.py
+++ b/tests/testing/test_queue_tests.py
@@ -49,3 +49,4 @@ class TestMockQueues(TestCase):
         self.queue.assertNothingPushed()
         self.queue.driver("database").push(JobWithArgs, args=(4,))
         self.queue.assertPushed(JobWithArgs)
+        self.queue.assertPushedWithArgs(JobWithArgs, (4,))

--- a/tests/testing/test_queue_tests.py
+++ b/tests/testing/test_queue_tests.py
@@ -50,3 +50,8 @@ class TestMockQueues(TestCase):
         self.queue.driver("database").push(JobWithArgs, args=(4,))
         self.queue.assertPushed(JobWithArgs)
         self.queue.assertPushedWithArgs(JobWithArgs, (4,))
+
+    def test_assert_not_pushed_jobs(self):
+        self.queue.assertNothingPushed()
+        self.queue.driver("database").push(Job)
+        self.queue.assertNotPushed(JobWithArgs)


### PR DESCRIPTION
The idea is to add a way to mock services (such as queue, emails, notifications ...) in the unit tests. When mocking, a MockTest class that we have to implement is used instead of the original class. On this class we can implement handy asserts methods.

Here a PoC has been made for
- Mail
- Queues 
- Notifications (in the other repo: https://github.com/girardinsamuel/notifications/pull/1)

Here are the new assertions helpers available:
```python
Mail.fake()

Mail.assertNothingSent()
Mail.assertCountAll(3)
Mail.assertSent(HelloMailable)
Mail.assertSent(HelloMailable, 2)

Mail.restore()
```

```python
Queue.fake()

Queue.assertNothingPushed()
Queue.assertPushed(Job)
Queue.assertPushed(OtherJob, 3)
Queue.assertPushedWithArgs(Job, ("a", "b"))
Queue.assertNotPushed(SomeJob)
Queue.assertPushedOn(OtherJob, "high-priority-queue", 2)

Queue.restore()
```

`fake` and `restore` can be used inside a test 

```python
    def test_mocking_mailgun(self):
        Mail.fake()
        Mail.driver('mailgun').to('user@example.com').html('<div>Hello</div>').send()
        Mail.assertCountAll(1)
        Mail.restore()
```

or the global test suite as below:

```python
class TestMailMocking(TestCase):

    def setUp(self):
        super().setUp()
        self.mail = Mail.fake()

    def tearDown(self):
        super().tearDown()
        self.mail = Mail.restore()

    def test_mocking_mailgun(self):
        self.mail.driver('mailgun').to('user@example.com').html('<div>Hello</div>').send()
        self.mail.assertCountAll(1)
```

### More on mails testing
```python
class TestMailable(Mailable):
    def build(self):
        return (self
            .to('idmann509@gmail.com')
            .send_from('admin@test.com')
            .view('emails.test', {"user": "Sam"})
            .reply_to('customer@email.com')
            .subject('Forgot Password'))


    def your_test(self):
        self.mail.driver('smtp').mailable(TestMailable()).send()
        self.mail.assertSent(
            TestMailable,
            lambda mailable: mailable.hasSubject("Forgot Password") \
                .hasTo('idmann509@gmail.com') \
                .hasReplyTo('customer@email.com') \
                .isSentFrom('admin@test.com') \
                .hasView('emails.test') \
                .hasInContext('user') \
                .hasInContext('user', 'Sam') \
                .hasContext({"user": "Sam"}) \
        )
```