### PR TITLE
update view() method on response to handle non responsable classes

### DIFF
--- a/src/masonite/response.py
+++ b/src/masonite/response.py
@@ -158,7 +158,7 @@ class Response(Extendable):
             return self.json(view.serialize(), status=self.get_status_code())
         elif isinstance(view, int):
             view = str(view)
-        elif isinstance(view, Responsable):
+        elif isinstance(view, Responsable) or hasattr(view, "get_response"):
             view = view.get_response()
         elif isinstance(view, self.request.__class__):
             view = self.data()


### PR DESCRIPTION
Now a class implementing `get_response()`  can be used to return a response without being an instance of `Responsable`.

It's useful to fix a bug in masonite-validation.