### PR TITLE
do not need decode to str when deserialize json to Python object

### DIFF
--- a/src/masonite/drivers/authentication/AuthJwtDriver.py
+++ b/src/masonite/drivers/authentication/AuthJwtDriver.py
@@ -9,7 +9,6 @@ from ...helpers import config, cookie_expire_time
 from ...app import App
 
 
-
 class AuthJwtDriver(BaseDriver, AuthContract):
     def __init__(self, app: App):
         """AuthCookieDriver initializer.

--- a/src/masonite/request.py
+++ b/src/masonite/request.py
@@ -309,9 +309,6 @@ class Request(Extendable):
 
             request_body = self.environ["wsgi.input"].read(request_body_size)
 
-            if isinstance(request_body, bytes):
-                request_body = request_body.decode("utf-8")
-
             return json.loads(request_body or "{}")
         else:
             fields = cgi.FieldStorage(

--- a/src/masonite/request.py
+++ b/src/masonite/request.py
@@ -346,13 +346,17 @@ class Request(Extendable):
         """Get the standardized value based on the type of the value parameter.
 
         Arguments:
-            value {list|dict|cgi.FileStorage|string}
+            value {list|dict|string|float|bool|cgi.FieldStorage}
 
         Returns:
-            string|bool
+            list|dict|string|float|bool|cgi.FieldStorage|None
         """
         if value is None:
             return None
+
+        # MiniFieldStorage without filename
+        if isinstance(value, MiniFieldStorage) and not value.filename:
+            return value.value
 
         if isinstance(value, list):
 
@@ -369,17 +373,9 @@ class Request(Extendable):
                 return values
 
             return value
-
-        if isinstance(value, (str, int, dict)):
-            return value
-
-        if not value.filename:
-            return value.value
-
-        if value.filename:
-            return value
-
-        return False
+        
+        # type is int, bool, float, string, or MiniFieldStorage with filename just return
+        return value
 
     def app(self):
         """Return the application container.

--- a/src/masonite/request.py
+++ b/src/masonite/request.py
@@ -373,7 +373,7 @@ class Request(Extendable):
                 return values
 
             return value
-        
+
         # type is int, bool, float, string, or MiniFieldStorage with filename just return
         return value
 

--- a/tests/core/test_requests.py
+++ b/tests/core/test_requests.py
@@ -495,6 +495,23 @@ class TestRequest(unittest.TestCase):
         self.assertEqual(request.input('2.item3.0'), 1)
         self.assertEqual(request.input('3.item3'), False)
 
+    def test_json_payload_gets_correct_type(self):
+        app = App()
+        wsgi_environ = generate_wsgi()
+        wsgi_environ['REQUEST_METHOD'] = 'POST'
+        wsgi_environ['CONTENT_TYPE'] = 'application/json'
+
+        route_class = Route()
+        request_class = Request()
+        app.bind('Request', request_class)
+        app.bind('Route', route_class)
+        route = app.make('Route')
+        request = app.make('Request').load_app(app)
+        wsgi_environ['wsgi.input'] = MockWsgiInput('{"int": 1, "float": 3.1415, "bool": false, "null": null}')
+        route.load_environ(wsgi_environ)
+        request.load_environ(wsgi_environ)
+        self.assertEqual(request.all(), {"int": 1, "float": 3.1415, "bool": False, "null": None})
+
     def test_list_as_root_payload_reset_between_requests(self):
         app = App()
         wsgi_environ = generate_wsgi()


### PR DESCRIPTION
[https://github.com/python/cpython/blob/71ef0b4c2b77195bb1adc42602549284f7ee9566/Lib/json/__init__.py#L301](https://github.com/python/cpython/blob/71ef0b4c2b77195bb1adc42602549284f7ee9566/Lib/json/__init__.py#L301)

"""Deserialize ``s`` (a ``str``, ``bytes`` or ``bytearray`` instance
    containing a JSON document) to a Python object.

json.loads may accept  str, bytes, bytearray, we don't need decode to str