### PR TITLE
Fix loading paths on Windows

### DIFF
--- a/src/masonite/utils/str.py
+++ b/src/masonite/utils/str.py
@@ -18,7 +18,7 @@ def random_string(length=4):
 
 
 def modularize(file_path, suffix=".py"):
-    """Transforms a file path to a dotted path.
+    """Transforms a file path to a dotted path. On UNIX paths contains / and on Windows \\.
 
     Keyword Arguments:
         file_path {str} -- A file path such app/controllers
@@ -27,7 +27,7 @@ def modularize(file_path, suffix=".py"):
         value {str} -- a dotted path such as app.controllers
     """
     # if the file had the .py extension remove it as it's not needed for a module
-    return removesuffix(file_path.replace("/", "."), suffix)
+    return removesuffix(file_path.replace("/", ".").replace("\\", "."), suffix)
 
 
 def as_filepath(dotted_path):


### PR DESCRIPTION
The modularize() function was not processing Windows paths correctly:
on UNIX:
```python
modularize("app/controllers.WelcomeController.py")  #== "app.controllers.WelcomeController"
```
on Windows
```python
modularize("app\\controllers.WelcomeController.py")  #== "app\\controllers.WelcomeController"
# and with the fix
modularize("app\\controllers.WelcomeController.py")  #== "app.controllers.WelcomeController"
```

Then the `load()` function was not working. now it's okay !