### PR TITLE
fix ServeCommand.py to use all expected host/port flags 

### DIFF
--- a/src/masonite/commands/ServeCommand.py
+++ b/src/masonite/commands/ServeCommand.py
@@ -65,8 +65,10 @@ def main(args=sys.argv[1:]):
     port = "8000"
     if "--host" in args:
         host = args[args.index("--host") + 1]
+    if "-b" in args:
+        host = args[args.index("-b") + 1]
     if "--port" in args:
-        port = args[args.index("--host") + 1]
+        port = args[args.index("--port") + 1]
     if "-p" in args:
         port = args[args.index("-p") + 1]
 


### PR DESCRIPTION
Fixes #472


Before these changes, here are the three unique errors that were occuring: 

1. `python craft serve -b 0.0.0.0 -p 12345` results in `Serving on http://localhost:12321` (wrong)
2. `python craft serve --host 0.0.0.0 -p 12345` results in `Serving on http://0.0.0.0:12321` (correct)
3. `python craft serve -b 0.0.0.0 --port 12345` results in `ValueError: '--host' is not in list` (wrong)
4. `python craft serve --host 0.0.0.0 --port 12345` results in `ValueError: invalid literal for int() with base 10: '0.0.0.0'` (wrong)



With my changes all three errors are fixed.

1. `python craft serve -b 0.0.0.0 -p 12345` results in `Serving on http://0.0.0.0:12321` (correct)
2. `python craft serve --host 0.0.0.0 -p 12345` results in `Serving on http://0.0.0.0:12321` (correct)
3. `python craft serve -b 0.0.0.0 --port 12345` results in `Serving on http://0.0.0.0:12321` (correct)
4. `python craft serve --host 0.0.0.0 --port 12345` results in `Serving on http://0.0.0.0:12321` (correct)