### PR TITLE
Add less coupling with Masonite ORM

### DIFF
--- a/src/masonite/authorization/Gate.py
+++ b/src/masonite/authorization/Gate.py
@@ -33,16 +33,14 @@ class Gate:
             self.policies[model_class] = policy_class
         return self
 
-    def get_policy_for(self, instance):
-        from masoniteorm import Model
-
-        if isinstance(instance, Model):
-            policy = self.policies.get(instance.__class__, None)
-        elif isclass(instance):
-            policy = self.policies.get(instance, None)
-        elif isinstance(instance, str):
+    def get_policy_for(self, instance_or_class):
+        if isinstance(instance_or_class, str):
             # TODO: load model from str, get class and get policies
             policy = None
+        elif isclass(instance_or_class):
+            policy = self.policies.get(instance_or_class, None)
+        else:
+            policy = self.policies.get(instance_or_class.__class__, None)
         if policy:
             return policy()
         else:

--- a/src/masonite/notification/NotificationManager.py
+++ b/src/masonite/notification/NotificationManager.py
@@ -2,7 +2,6 @@
 import uuid
 
 from ..exceptions.exceptions import NotificationException
-from ..utils.collections import Collection
 from .AnonymousNotifiable import AnonymousNotifiable
 
 
@@ -73,6 +72,8 @@ class NotificationManager:
         return results[0] if len(results) == 1 else results
 
     def _format_notifiables(self, notifiables):
+        from masoniteorm.collection import Collection
+
         if isinstance(notifiables, (list, tuple, Collection)):
             return notifiables
         else:

--- a/src/masonite/notification/NotificationManager.py
+++ b/src/masonite/notification/NotificationManager.py
@@ -2,7 +2,7 @@
 import uuid
 
 from ..exceptions.exceptions import NotificationException
-from ..queues import ShouldQueue
+from ..utils.collections import Collection
 from .AnonymousNotifiable import AnonymousNotifiable
 
 
@@ -73,8 +73,6 @@ class NotificationManager:
         return results[0] if len(results) == 1 else results
 
     def _format_notifiables(self, notifiables):
-        from masoniteorm.collection import Collection
-
         if isinstance(notifiables, (list, tuple, Collection)):
             return notifiables
         else:

--- a/tests/core/authentication/test_authentication2.py
+++ b/tests/core/authentication/test_authentication2.py
@@ -1,8 +1,4 @@
 from tests import TestCase
-from src.masonite.foundation import Application
-import os
-from masoniteorm.models import Model
-from src.masonite.authentication import Authenticates, Auth
 
 
 class TestAuthentication(TestCase):

--- a/tests/features/notification/test_database_driver.py
+++ b/tests/features/notification/test_database_driver.py
@@ -1,6 +1,6 @@
-from masoniteorm import connections
-from masoniteorm.models import Model
 import pendulum
+
+from masoniteorm.models import Model
 
 from tests import TestCase
 from src.masonite.tests import DatabaseTransactions


### PR DESCRIPTION
- remove unused imports
- rewrite objects policy to remove orm dependency
- lazy load ORM when possible
