### PR TITLE
Fix publishing views

### DIFF
--- a/src/masonite/packages/Package.py
+++ b/src/masonite/packages/Package.py
@@ -32,9 +32,13 @@ class Package:
         self.config = self._build_module_path(config_path)
         return self
 
-    def add_views(self, *locations):
-        for location in locations:
-            self.views.append(self._build_module_path(location))
+    def add_views(self, location):
+        views_folder = self._build_module_path(location)
+        if not os.path.isdir(views_folder):
+            raise ValueError(
+                "views() first argument must be a folder containing all package views."
+            )
+        self.views = views_folder
         return self
 
     def add_migrations(self, *migrations):

--- a/src/masonite/packages/Package.py
+++ b/src/masonite/packages/Package.py
@@ -34,7 +34,7 @@ class Package:
 
     def add_views(self, location):
         views_folder = self._build_module_path(location)
-        if not os.path.isdir(views_folder):
+        if not os.path.isdir(self._build_path(location)):
             raise ValueError(
                 "views() first argument must be a folder containing all package views."
             )

--- a/src/masonite/packages/providers/PackageProvider.py
+++ b/src/masonite/packages/providers/PackageProvider.py
@@ -87,9 +87,7 @@ class PackageProvider(Provider):
         return self
 
     def views(self, location, publish=False):
-        """Register views location in the project.
-        locations must be a folder containinng the views you want to publish.
-        """
+        """Register views location in the project. location must be a folder containinng the views you want to publish."""
         self.package.add_views(location)
         # register views into project
         self.application.make("view").add_namespaced_location(

--- a/src/masonite/packages/providers/PackageProvider.py
+++ b/src/masonite/packages/providers/PackageProvider.py
@@ -86,34 +86,32 @@ class PackageProvider(Provider):
             )
         return self
 
-    def views(self, *locations, publish=False):
+    def views(self, location, publish=False):
         """Register views location in the project.
         locations must be a folder containinng the views you want to publish.
         """
-        self.package.add_views(*locations)
+        self.package.add_views(location)
         # register views into project
-        for view in self.package.views:
-            self.application.make("view").add_namespaced_location(
-                self.package.name, view
-            )
+        self.application.make("view").add_namespaced_location(
+            self.package.name, self.package.views
+        )
 
         if publish:
-            for location in locations:
-                location_abs_path = self.package._build_path(location)
-                for dirpath, _, filenames in os.walk(location_abs_path):
-                    for f in filenames:
-                        view_abs_path = join(dirpath, f)
-                        self.package.add_publishable_resource(
-                            "views",
-                            view_abs_path,
-                            views_path(
-                                join(
-                                    self.vendor_prefix,
-                                    self.package.name,
-                                    relpath(view_abs_path, location_abs_path),
-                                )
-                            ),
-                        )
+            location_abs_path = self.package._build_path(location)
+            for dirpath, _, filenames in os.walk(location_abs_path):
+                for f in filenames:
+                    view_abs_path = join(dirpath, f)
+                    self.package.add_publishable_resource(
+                        "views",
+                        view_abs_path,
+                        views_path(
+                            join(
+                                self.vendor_prefix,
+                                self.package.name,
+                                relpath(view_abs_path, location_abs_path),
+                            )
+                        ),
+                    )
 
         return self
 

--- a/src/masonite/packages/providers/PackageProvider.py
+++ b/src/masonite/packages/providers/PackageProvider.py
@@ -98,7 +98,11 @@ class PackageProvider(Provider):
             location_abs_path = self.package._build_path(location)
             for dirpath, _, filenames in os.walk(location_abs_path):
                 for f in filenames:
+                    # don't add other files than templates
                     view_abs_path = join(dirpath, f)
+                    _, ext = os.path.splitext(view_abs_path)
+                    if ext != ".html":
+                        continue
                     self.package.add_publishable_resource(
                         "views",
                         view_abs_path,

--- a/src/masonite/packages/providers/PackageProvider.py
+++ b/src/masonite/packages/providers/PackageProvider.py
@@ -92,9 +92,10 @@ class PackageProvider(Provider):
         """
         self.package.add_views(*locations)
         # register views into project
-        self.application.make("view").add_namespace(
-            self.package.name, self.package.views[0]
-        )
+        for view in self.package.views:
+            self.application.make("view").add_namespaced_location(
+                self.package.name, view
+            )
 
         if publish:
             for location in locations:

--- a/src/masonite/views/view.py
+++ b/src/masonite/views/view.py
@@ -183,13 +183,6 @@ class View:
     def add_from_package(self, package_name, path_in_package):
         self.environments.append(PackageLoader(package_name, path_in_package))
 
-    def add_namespace(self, namespace, path):
-        self.namespaces[namespace].append(
-            views_path(f"vendor/{namespace}/", absolute=False)
-        )
-        # put this one in 2nd as project (overriden) views must be used first
-        self.namespaces[namespace].append(path)
-
     def filter(self, name, function):
         """Use to add filters to views.
 

--- a/src/masonite/views/view.py
+++ b/src/masonite/views/view.py
@@ -184,7 +184,6 @@ class View:
         self.environments.append(PackageLoader(package_name, path_in_package))
 
     def add_namespace(self, namespace, path):
-        # TODO: if views have been published, add an other path corresponding to this namespace
         self.namespaces[namespace].append(
             views_path(f"vendor/{namespace}/", absolute=False)
         )


### PR DESCRIPTION
Fixes #493.

- [x] PackageProvider `views()` method now accepts only one folder. This folder should contain all the views you want to be able to use / publish when the package is installed.
- [x] Removed a duplicated method in View
- [x] Fixed publishing only .html in views folder to avoid this:
<img width="616" alt="image" src="https://user-images.githubusercontent.com/9897999/150386393-3541a6e4-2a55-4acd-a713-b8c15357ab68.png">
