### PR TITLE
Fix `routes:list` command when using controller method in route declaration

### DIFF
--- a/src/masonite/routes/commands/RouteListCommand.py
+++ b/src/masonite/routes/commands/RouteListCommand.py
@@ -54,11 +54,17 @@ class RouteListCommand(Command):
 
     def format_route_as_row(self, route):
         """Format a Route object as a table row."""
+        # format controller name
+        if callable(route.controller):
+            # ControllerClassName.index -> ControllerClassName@index
+            controller = route.controller.__qualname__.replace(".", "@")
+        else:
+            controller = str(route.controller)
         row = [
             route.url,
             route.get_name() or "",
             "/".join(map(lambda m: m.upper(), route.request_method)),
-            route.controller,
+            controller,
             ",".join(route.list_middleware),
         ]
         return row


### PR DESCRIPTION
When using `Route.get("/", SomeController.method)` instead of `Route.get("/", "SomeController@method")` the `routes:list`command was not working. No both syntaxes gives the same output in `routes:list`command.