### PR TITLE
Add ability to run given task from schedule and to force task(s) to be run immediately

### DIFF
--- a/src/masonite/scheduling/TaskHandler.py
+++ b/src/masonite/scheduling/TaskHandler.py
@@ -1,4 +1,3 @@
-import pendulum
 import inspect
 
 
@@ -13,7 +12,7 @@ class TaskHandler:
     def add(self, *tasks):
         self.tasks += list(tasks)
 
-    def run(self, run_name=None):
+    def run(self, run_name=None, force=False):
         app = self.application
         for task_class in self.tasks:
             # Resolve the task with the container
@@ -26,5 +25,5 @@ class TaskHandler:
                 task = task_class
 
             # If the class should run then run it
-            if task.should_run():
+            if task.should_run() or force:
                 task.handle()

--- a/src/masonite/scheduling/commands/ScheduleRunCommand.py
+++ b/src/masonite/scheduling/commands/ScheduleRunCommand.py
@@ -1,16 +1,13 @@
 """ A ScheduleRunCommand Command """
-import pendulum
-import inspect
 from cleo import Command
-
-from ..Task import Task
 
 
 class ScheduleRunCommand(Command):
     """
     Run the scheduled tasks
     schedule:run
-        {--t|task=None : Name of task you want to run}
+        {--t|task=? : Name of task you want to run (else all scheduled tasks will be ran)}
+        {--f|force : Force running task immediately}
     """
 
     def __init__(self, application):
@@ -18,4 +15,6 @@ class ScheduleRunCommand(Command):
         self.app = application
 
     def handle(self):
-        return self.app.make("scheduler").run()
+        return self.app.make("scheduler").run(
+            run_name=self.option("task"), force=self.option("force")
+        )


### PR DESCRIPTION
Fixes #513 

- We can now run `python craft schedule:run --task MyTask` to run a specific task in the schedule.
- We can additionally force the task to run even if it should not be ran right now with `--force` flag.