### PR TITLE
Add `application` to Jinja2 environment to make it accessible in custom extensions

### DIFF
--- a/src/masonite/views/view.py
+++ b/src/masonite/views/view.py
@@ -255,6 +255,9 @@ class View:
             extensions=self._jinja_extensions,
             line_statement_prefix="@",
         )
+        # add container to environment so that extensions can use it
+        self.env.application = self.application
+
         # add filters to environment
         self.env.filters.update(self._filters)
 


### PR DESCRIPTION
In Jinja2 extensions that we can develop we can now do:
```python

class MyExtension(Extension):
# ...
    self.environment.application  # == Masonite app container
```
