### PR TITLE
Changing signature of Gate.register_policies

### DIFF
--- a/src/masonite/authorization/Gate.py
+++ b/src/masonite/authorization/Gate.py
@@ -28,9 +28,9 @@ class Gate:
 
         self.permissions.update({permission: condition})
 
-    def register_policies(self, policies):
-        for model_class, policy_class in policies:
-            self.policies[model_class] = policy_class
+    def register_policies(self, *policies):
+        for policy_class in policies:
+            self.policies[policy_class.model] = policy_class
         return self
 
     def get_policy_for(self, instance_or_class):
@@ -41,8 +41,9 @@ class Gate:
             policy = self.policies.get(instance_or_class, None)
         else:
             policy = self.policies.get(instance_or_class.__class__, None)
+       
         if policy:
-            return policy()
+            return policy
         else:
             return None
 

--- a/src/masonite/authorization/Gate.py
+++ b/src/masonite/authorization/Gate.py
@@ -41,7 +41,7 @@ class Gate:
             policy = self.policies.get(instance_or_class, None)
         else:
             policy = self.policies.get(instance_or_class.__class__, None)
-       
+
         if policy:
             return policy
         else:

--- a/src/masonite/authorization/Policy.py
+++ b/src/masonite/authorization/Policy.py
@@ -2,7 +2,6 @@ from .AuthorizationResponse import AuthorizationResponse
 
 
 class Policy:
-    
     def __init__(self, model):
         self.model = model
 

--- a/src/masonite/authorization/Policy.py
+++ b/src/masonite/authorization/Policy.py
@@ -2,6 +2,10 @@ from .AuthorizationResponse import AuthorizationResponse
 
 
 class Policy:
+    
+    def __init__(self, model):
+        self.model = model
+
     def allow(self, message="", code=None):
         return AuthorizationResponse.allow(message, code)
 

--- a/src/masonite/stubs/policies/ModelPolicy.py
+++ b/src/masonite/stubs/policies/ModelPolicy.py
@@ -2,6 +2,10 @@ from masonite.authorization import Policy
 
 
 class __class__(Policy):
+
+    def __init__(self, model):
+        self.model = model
+        
     def create(self, user):
         return False
 

--- a/src/masonite/stubs/policies/ModelPolicy.py
+++ b/src/masonite/stubs/policies/ModelPolicy.py
@@ -2,10 +2,9 @@ from masonite.authorization import Policy
 
 
 class __class__(Policy):
-
     def __init__(self, model):
         self.model = model
-        
+
     def create(self, user):
         return False
 

--- a/tests/core/authorization/test_policies.py
+++ b/tests/core/authorization/test_policies.py
@@ -2,6 +2,7 @@ from tests import TestCase
 from masoniteorm.models import Model
 
 from tests.integrations.policies.PostPolicy import PostPolicy
+from tests.integrations.policies.UserPolicy import UserPolicy
 from src.masonite.exceptions.exceptions import PolicyDoesNotExist
 
 
@@ -27,11 +28,12 @@ class TestPolicies(TestCase):
         self.gate.permissions = {}
 
     def test_can_register_policies(self):
-        self.gate.register_policies([(Post, PostPolicy)])
-        self.assertEqual(self.gate.policies[Post], PostPolicy)
+        self.gate.register_policies(PostPolicy(Post), UserPolicy(User))
+        self.assertEqual(type(self.gate.policies[Post]), type(PostPolicy(Post)))
+        self.assertEqual(type(self.gate.policies[User]), type(UserPolicy(User)))
 
     def test_using_policies_with_argument(self):
-        self.gate.register_policies([(Post, PostPolicy)])
+        self.gate.register_policies(PostPolicy(Post))
         post = Post()
         post.user_id = 1
         # authenticates user 1
@@ -39,14 +41,14 @@ class TestPolicies(TestCase):
         self.assertTrue(self.gate.allows("update", post))
 
     def test_using_policies_without_argument(self):
-        self.gate.register_policies([(Post, PostPolicy)])
+        self.gate.register_policies(PostPolicy(Post))
         # authenticates user 1
         self.application.make("auth").attempt("idmann509@gmail.com", "secret")
 
         self.assertTrue(self.gate.allows("create", Post))
 
     def test_using_policy_returning_response(self):
-        self.gate.register_policies([(Post, PostPolicy)])
+        self.gate.register_policies(PostPolicy(Post))
         # authenticates user 1
         self.application.make("auth").attempt("idmann509@gmail.com", "secret")
         post = Post()
@@ -65,11 +67,11 @@ class TestPolicies(TestCase):
         self.assertTrue(self.gate.allows("update", post))
 
     def test_that_policy_can_allow_guest_users(self):
-        self.gate.register_policies([(Post, PostPolicy)])
+        self.gate.register_policies(PostPolicy(Post))
         self.assertTrue(self.gate.allows("view_any", Post))
 
     def test_any_on_policy(self):
-        self.gate.register_policies([(Post, PostPolicy)])
+        self.gate.register_policies(PostPolicy(Post))
         post = Post()
         post.user_id = 1
         # authenticates user 1
@@ -77,6 +79,6 @@ class TestPolicies(TestCase):
         self.assertTrue(self.gate.any(["update", "delete"], post))
 
     def test_unknown_policy_method_raises_exception(self):
-        self.gate.register_policies([(Post, PostPolicy)])
+        self.gate.register_policies(PostPolicy(Post))
         with self.assertRaises(PolicyDoesNotExist):
             self.gate.allows("can-fly", Post)

--- a/tests/features/hashid/test_hashid_middleware.py
+++ b/tests/features/hashid/test_hashid_middleware.py
@@ -17,16 +17,13 @@ class TestHashID(TestCase):
         assert not hashid("B8I6ub", decode=True)
 
     def test_hashid_can_decode_dictionary(self):
-        assert (
-            hashid(
-                {
-                    "id": "l9avmeG",
-                    "name": "Joe",
-                },
-                decode=True,
-            )
-            == {"id": 10, "name": "Joe"}
-        )
+        assert hashid(
+            {
+                "id": "l9avmeG",
+                "name": "Joe",
+            },
+            decode=True,
+        ) == {"id": 10, "name": "Joe"}
 
     def test_middleware(self):
         request = self.make_request(query_string="id=l9avmeG&name=Joe")

--- a/tests/integrations/policies/UserPolicy.py
+++ b/tests/integrations/policies/UserPolicy.py
@@ -1,0 +1,6 @@
+from src.masonite.authorization import Policy
+
+
+class UserPolicy(Policy):
+    def view(self, user):
+        return True


### PR DESCRIPTION
Fix #529 
Changing the signature of 'Gate.register_policies' to receive a Policy class with model related injected in constructor.