### PR TITLE
Fix parsing post data

### DIFF
--- a/src/masonite/input/InputBag.py
+++ b/src/masonite/input/InputBag.py
@@ -56,11 +56,6 @@ class InputBag:
                 self.post_data = self.parse_dict(parsed_request_body)
 
             elif "multipart/form-data" in environ.get("CONTENT_TYPE", ""):
-                try:
-                    request_body_size = int(environ.get("CONTENT_LENGTH", 0))
-                except (ValueError):
-                    request_body_size = 0
-
                 fields = cgi.FieldStorage(
                     fp=environ["wsgi.input"],
                     environ=environ,

--- a/src/masonite/input/InputBag.py
+++ b/src/masonite/input/InputBag.py
@@ -201,9 +201,9 @@ class InputBag:
                     else:
                         d.setdefault(gd["name"], {})[gd["value"]] = value[0]
                 else:
-                    try:
+                    if isinstance(value, (list, tuple)):
                         d.update({name: value[0]})
-                    except TypeError:
+                    else:
                         d.update({name: value})
 
         new_dict = {}

--- a/tests/core/request/test_input.py
+++ b/tests/core/request/test_input.py
@@ -133,8 +133,8 @@ class TestInput(TestCase):
             {
                 "REQUEST_METHOD": "POST",
                 "CONTENT_TYPE": content_type,
-                "CONTENT_LENGTH": str(len(data.encode("latin-1"))),
-                "wsgi.input": io.BytesIO(data.encode("latin-1")),
+                "CONTENT_LENGTH": str(len(data.encode("utf-8"))),
+                "wsgi.input": io.BytesIO(data.encode("utf-8")),
             }
         )
 

--- a/tests/core/request/test_input.py
+++ b/tests/core/request/test_input.py
@@ -148,7 +148,7 @@ class TestInput(TestCase):
         self.assertEqual(bag.get("a.b.c"), 1)
 
         # multipart/form-data
-        data, content_type = encode_multipart_formdata({"key": "value"})
+        data, content_type = encode_multipart_formdata({"key": "value", "test": 1})
         bag = InputBag()
         bag.load(
             {

--- a/tests/core/request/test_request_input.py
+++ b/tests/core/request/test_request_input.py
@@ -24,7 +24,10 @@ class TestRequest(TestCase):
         self.request.input_bag.query_string = {"test": 3.1415926}
         self.assertEqual(self.request.input("test"), 3.1415926)
 
-    def test_request_can_get_nested_value(self):
-        # from query string
+    def test_request_can_get_nested_value_from_query_string(self):
         self.request.input_bag.query_string = {"key": "val", "a": {"b": {"c": 1}}}
+        self.assertEqual(self.request.input("a.b.c"), 1)
+
+    def test_request_can_get_nested_value_from_post_data(self):
+        self.request.input_bag.post_data = {"key": "val", "a": {"b": {"c": 1}}}
         self.assertEqual(self.request.input("a.b.c"), 1)


### PR DESCRIPTION
- [x] add failing test
- [x] fix behaviour

I have added a test for each content type including the one which was not working (i.e. `multipart/form-data`) so that we can better prevent regression errors.
It would maybe need more tests as it's dealing with user inputs and there are lot of edge cases, but it should be good for now.