### PR TITLE
Add new testing assertions to test console output and errors

### DIFF
--- a/src/masonite/tests/TestCase.py
+++ b/src/masonite/tests/TestCase.py
@@ -66,7 +66,9 @@ class TestCase(unittest.TestCase):
 
     @pytest.fixture(autouse=True)
     def _pass_fixtures(self, capsys):
-        """Add all useful pytest fixtures to unittest."""
+        """Add all useful pytest fixtures to unittest.
+        In the future, when needed more pytest fixtures could be integrated to Masonite TestCase.
+        """
         # 'capsys' fixture allow to read output/error from stdout/stderr
         self.capsys = capsys
 
@@ -77,50 +79,50 @@ class TestCase(unittest.TestCase):
             self._console_out = output.out
             self._console_err = output.err
 
-    def assertConsoleEmpty(self):
+    def assertConsoleEmpty(self) -> "TestCase":
         """Assert that nothing (output or error) has been printed to the console."""
         self._readConsoleOutput()
         self.assertEqual("", self._console_out)
         self.assertEqual("", self._console_err)
         return self
 
-    def assertConsoleNotEmpty(self):
+    def assertConsoleNotEmpty(self) -> "TestCase":
         """Assert that something (output or error) has been printed to the console."""
         self._readConsoleOutput()
         assert self._console_out != "" or self._console_err != ""
         return self
 
-    def assertConsoleExactOutput(self, output):
+    def assertConsoleExactOutput(self, output: str) -> "TestCase":
         """Assert that console standard output is equal to given output."""
         self._readConsoleOutput()
         self.assertEqual(output, self._console_out)
         return self
 
-    def assertConsoleOutputContains(self, output):
+    def assertConsoleOutputContains(self, output: str) -> "TestCase":
         """Assert that console standard output contains given output."""
         self._readConsoleOutput()
         self.assertIn(output, self._console_out)
         return self
 
-    def assertConsoleOutputMissing(self, output):
+    def assertConsoleOutputMissing(self, output: str) -> "TestCase":
         """Assert that console standard output does not contain the given output."""
         self._readConsoleOutput()
         self.assertNotIn(output, self._console_out)
         return self
 
-    def assertConsoleHasErrors(self):
+    def assertConsoleHasErrors(self) -> "TestCase":
         """Assert that something has been output to console standard error."""
         self._readConsoleOutput()
         self.assertNotEqual(self._console_err, "")
         return self
 
-    def assertConsoleExactError(self, error):
+    def assertConsoleExactError(self, error: str) -> "TestCase":
         """Assert that console standard error is equal to given error."""
         self._readConsoleOutput()
         self.assertEqual(error, self._console_err)
         return self
 
-    def assertConsoleErrorContains(self, error):
+    def assertConsoleErrorContains(self, error: str) -> "TestCase":
         """Assert that console standard error contains given error."""
         self._readConsoleOutput()
         self.assertIn(error, self._console_err)

--- a/src/masonite/tests/TestCase.py
+++ b/src/masonite/tests/TestCase.py
@@ -84,7 +84,13 @@ class TestCase(unittest.TestCase):
         self.assertEqual("", self._console_err)
         return self
 
-    def assertConsoleOutput(self, output):
+    def assertConsoleNotEmpty(self):
+        """Assert that something (output or error) has been printed to the console."""
+        self._readConsoleOutput()
+        assert self._console_out != "" or self._console_err != ""
+        return self
+
+    def assertConsoleExactOutput(self, output):
         """Assert that console standard output is equal to given output."""
         self._readConsoleOutput()
         self.assertEqual(output, self._console_out)
@@ -96,7 +102,19 @@ class TestCase(unittest.TestCase):
         self.assertIn(output, self._console_out)
         return self
 
-    def assertConsoleError(self, error):
+    def assertConsoleOutputMissing(self, output):
+        """Assert that console standard output does not contain the given output."""
+        self._readConsoleOutput()
+        self.assertNotIn(output, self._console_out)
+        return self
+
+    def assertConsoleHasErrors(self):
+        """Assert that something has been output to console standard error."""
+        self._readConsoleOutput()
+        self.assertNotEqual(self._console_err, "")
+        return self
+
+    def assertConsoleExactError(self, error):
         """Assert that console standard error is equal to given error."""
         self._readConsoleOutput()
         self.assertEqual(error, self._console_err)

--- a/src/masonite/tests/TestCase.py
+++ b/src/masonite/tests/TestCase.py
@@ -71,6 +71,7 @@ class TestCase(unittest.TestCase):
         self.capsys = capsys
 
     def _readConsoleOutput(self):
+        """Read console output if it has not been read yet."""
         if self._console_out is None and self._console_err is None:
             output = self.capsys.readouterr()
             self._console_out = output.out

--- a/tests/tests/test_testcase.py
+++ b/tests/tests/test_testcase.py
@@ -1,6 +1,7 @@
 import pendulum
 import os
 import pytest
+import sys
 
 from tests import TestCase
 from tests.integrations.controllers.WelcomeController import WelcomeController
@@ -337,3 +338,27 @@ class TestTestingAssertions(TestCase):
         self.assertDatabaseMissing(
             "users", {"name": "John", "email": "john@example.com"}
         )
+
+    def test_assertConsoleEmpty(self):
+        self.assertConsoleEmpty()
+
+    def test_assertConsoleOutput(self):
+        print("Hello World !")
+        self.assertConsoleOutput("Hello World !\n")
+
+    def test_assertConsoleOutputContains(self):
+        print("Hello World !")
+        self.assertConsoleOutputContains("Hello")
+
+    def test_assertConsoleError(self):
+        print("Fatal Error !", file=sys.stderr)
+        self.assertConsoleError("Fatal Error !\n")
+
+    def test_assertConsoleErrorContains(self):
+        print("Fatal Error !", file=sys.stderr)
+        self.assertConsoleErrorContains("Error")
+
+    def test_make_multiple_output_assertions(self):
+        print("Hello World !")
+        self.assertConsoleOutput("Hello World !\n")
+        self.assertConsoleOutputContains("Hello")

--- a/tests/tests/test_testcase.py
+++ b/tests/tests/test_testcase.py
@@ -339,26 +339,38 @@ class TestTestingAssertions(TestCase):
             "users", {"name": "John", "email": "john@example.com"}
         )
 
-    def test_assertConsoleEmpty(self):
+    def test_assert_console_empty(self):
         self.assertConsoleEmpty()
 
-    def test_assertConsoleOutput(self):
-        print("Hello World !")
-        self.assertConsoleOutput("Hello World !\n")
+    def test_assert_console_not_empty(self):
+        print("test")
+        self.assertConsoleNotEmpty()
 
-    def test_assertConsoleOutputContains(self):
+    def test_assert_console_exact_output(self):
+        print("Hello World !")
+        self.assertConsoleExactOutput("Hello World !\n")
+
+    def test_assert_console_output_missing(self):
+        print("Hello World !")
+        self.assertConsoleOutputMissing("Not there")
+
+    def test_assert_console_output_contains(self):
         print("Hello World !")
         self.assertConsoleOutputContains("Hello")
 
-    def test_assertConsoleError(self):
+    def test_assert_console_has_errors(self):
         print("Fatal Error !", file=sys.stderr)
-        self.assertConsoleError("Fatal Error !\n")
+        self.assertConsoleHasErrors()
 
-    def test_assertConsoleErrorContains(self):
+    def test_assert_console_exact_error(self):
+        print("Fatal Error !", file=sys.stderr)
+        self.assertConsoleExactError("Fatal Error !\n")
+
+    def test_assert_console_error_contains(self):
         print("Fatal Error !", file=sys.stderr)
         self.assertConsoleErrorContains("Error")
 
     def test_make_multiple_output_assertions(self):
         print("Hello World !")
-        self.assertConsoleOutput("Hello World !\n")
+        self.assertConsoleExactOutput("Hello World !\n")
         self.assertConsoleOutputContains("Hello")


### PR DESCRIPTION
Those assertions will be useful to assert that something has been printed in the console by your code or has been output by an other process during unit tests 🚀.

- removed `captureOutput` context manager which was not working anyway
- add following testing assertions:

```python
self.assertConsoleEmpty()
self.assertConsoleNotEmpty()
self.assertConsoleExactOutput("Hello World !\n")
self.assertConsoleOutputContains("Hello")
self.assertConsoleOutputMissing("Hello")
self.assertConsoleHasErrors()
self.assertConsoleExactError("Fatal Error !\n")
self.assertConsoleErrorContains("Error")
```
Assertions match existing assertions when testing commands for more consistency !

You can call those assertions multiple time in the same unit test once something has been output.
It will be reset between each unit test.

Doc here:
https://github.com/MasoniteFramework/docs/pull/184
