### PR TITLE
Fix merging Mailable options with general `mail` options

### DIFF
--- a/src/masonite/mail/Mail.py
+++ b/src/masonite/mail/Mail.py
@@ -29,7 +29,8 @@ class Mail:
 
     def send(self, driver=None):
         selected_driver = driver or self.options.get("driver", None)
-        if not self.options.get("from"):
-            self.options.pop("from")
-        self.options.update(self.get_config_options(selected_driver))
+        config_options = self.get_config_options(selected_driver)
+        if self.options.get("from"):
+            config_options.pop("from", None)
+        self.options.update(config_options)
         return self.get_driver(selected_driver).set_options(self.options).send()

--- a/src/masonite/mail/Mail.py
+++ b/src/masonite/mail/Mail.py
@@ -30,6 +30,7 @@ class Mail:
     def send(self, driver=None):
         selected_driver = driver or self.options.get("driver", None)
         config_options = self.get_config_options(selected_driver)
+        # if an option has already been defined in a mailable use it
         if self.options.get("from"):
             config_options.pop("from", None)
         self.options.update(config_options)

--- a/src/masonite/mail/Mail.py
+++ b/src/masonite/mail/Mail.py
@@ -29,5 +29,7 @@ class Mail:
 
     def send(self, driver=None):
         selected_driver = driver or self.options.get("driver", None)
+        if not self.options.get("from"):
+            self.options.pop("from")
         self.options.update(self.get_config_options(selected_driver))
         return self.get_driver(selected_driver).set_options(self.options).send()

--- a/src/masonite/mail/MockMail.py
+++ b/src/masonite/mail/MockMail.py
@@ -9,8 +9,15 @@ class MockMail(Mail):
         self.driver = None
 
     def send(self, driver=None):
-        self.driver = config("mail.drivers.default")
-        self.driver = driver or self.options.get("driver", None)
+        if driver:
+            self.driver = driver
+        else:
+            self.driver = self.options.get("driver", None) or config(
+                "mail.drivers.default"
+            )
+        if not self.options.get("from"):
+            self.options.pop("from")
+        self.options.update(self.get_config_options(self.driver))
         self.count += 1
         return self
 
@@ -105,5 +112,7 @@ class MockMail(Mail):
         return self
 
     def seeDriverWas(self, name):
-        assert self.driver == name, f"Expected email driver to be {name} but it was {self.driver}"
+        assert (
+            self.driver == name
+        ), f"Expected email driver to be {name} but it was {self.driver}"
         return self

--- a/src/masonite/mail/MockMail.py
+++ b/src/masonite/mail/MockMail.py
@@ -9,6 +9,7 @@ class MockMail(Mail):
         self.driver = None
 
     def reset(self):
+        """Reset mock implementation."""
         self.count = 0
         self.driver = None
 

--- a/src/masonite/mail/MockMail.py
+++ b/src/masonite/mail/MockMail.py
@@ -8,6 +8,10 @@ class MockMail(Mail):
         self.count = 0
         self.driver = None
 
+    def reset(self):
+        self.count = 0
+        self.driver = None
+
     def send(self, driver=None):
         if driver:
             self.driver = driver
@@ -15,9 +19,11 @@ class MockMail(Mail):
             self.driver = self.options.get("driver", None) or config(
                 "mail.drivers.default"
             )
-        if not self.options.get("from"):
-            self.options.pop("from")
-        self.options.update(self.get_config_options(self.driver))
+
+        config_options = self.get_config_options(self.driver)
+        if self.options.get("from"):
+            config_options.pop("from", None)
+        self.options.update(config_options)
         self.count += 1
         return self
 

--- a/src/masonite/providers/MailProvider.py
+++ b/src/masonite/providers/MailProvider.py
@@ -16,7 +16,10 @@ class MailProvider(Provider):
         mail.add_driver("mailgun", MailgunDriver(self.application))
         mail.add_driver("terminal", TerminalDriver(self.application))
         self.application.bind("mail", mail)
-        self.application.bind("mock.mail", MockMail)
+        mocked_mail = MockMail(self.application).set_configuration(
+            Config.get("mail.drivers")
+        )
+        self.application.bind("mock.mail", mocked_mail)
 
     def boot(self):
         pass

--- a/src/masonite/tests/TestCase.py
+++ b/src/masonite/tests/TestCase.py
@@ -211,6 +211,8 @@ class TestCase(unittest.TestCase):
         )
         # mock by overriding with mocked version
         mock = self.application.make(f"mock.{binding}", self.application)
+        if hasattr(mock, "reset"):
+            mock.reset()
         self.application.bind(binding, mock)
         return mock
 

--- a/tests/core/foundation/test_facades.py
+++ b/tests/core/foundation/test_facades.py
@@ -4,7 +4,9 @@ from src.masonite.facades import Mail, View
 
 class TestFacades(TestCase):
     def test_mail_facade(self):
-        self.assertIsNone(Mail.get_config_options("mailgun")["domain"])
+        self.assertEqual(
+            Mail.get_config_options("mailgun")["from"], "no-reply@masonite.com"
+        )
 
     def test_view_facade(self):
         View.add_location("tests/integrations/templates")

--- a/tests/features/mail/test_mailable.py
+++ b/tests/features/mail/test_mailable.py
@@ -70,17 +70,6 @@ class TestMailable(TestCase):
             "Joseph Mancuso <idmann509@gmail.com>, <joe@masoniteproject.com>",
         )
 
-    def test_recipient(self):
-        to = Recipient("idmann509@gmail.com, joe@masoniteproject.com")
-        self.assertEqual(
-            to.header(), "<idmann509@gmail.com>, <joe@masoniteproject.com>"
-        )
-        to = Recipient("Joseph Mancuso <idmann509@gmail.com>, joe@masoniteproject.com")
-        self.assertEqual(
-            to.header(),
-            "Joseph Mancuso <idmann509@gmail.com>, <joe@masoniteproject.com>",
-        )
-
         to = Recipient(
             ["Joseph Mancuso <idmann509@gmail.com>", "joe@masoniteproject.com"]
         )

--- a/tests/features/mail/test_mailgun_driver.py
+++ b/tests/features/mail/test_mailgun_driver.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tests import TestCase
 from src.masonite.mail import Mailable
 
@@ -17,6 +18,13 @@ class Welcome(Mailable):
 @pytest.mark.integrations
 class TestMailgunDriver(TestCase):
     def test_send_mailable(self):
-        self.application.make("mail").mailable(
-            Welcome().attach("invoice", "tests/integrations/storage/invoice.pdf")
+        response = (
+            self.application.make("mail")
+            .mailable(
+                Welcome().attach("invoice", "tests/integrations/storage/invoice.pdf")
+            )
+            .send(driver="mailgun")
         )
+        self.assertEqual(response.status_code, 200)
+        # because domain is not configured we got this funny message !
+        self.assertEqual("Mailgun Magnificent API", response.content.decode("utf-8"))

--- a/tests/features/mail/test_mock_mail.py
+++ b/tests/features/mail/test_mock_mail.py
@@ -33,7 +33,6 @@ class TestSMTPDriver(TestCase):
         self.restore("mail")
 
     def test_mock_mail(self):
-        self.fake("mail")
         welcome_email = self.application.make("mail").mailable(Welcome()).send()
         (
             welcome_email.seeEmailCc("")
@@ -47,11 +46,9 @@ class TestSMTPDriver(TestCase):
         )
 
     def test_mock_mail_sending(self):
-        self.fake("mail")
         welcome_email = self.application.make("mail").mailable(Welcome())
         (welcome_email.seeEmailWasNotSent().send().seeEmailWasSent())
 
     def test_mock_can_also_handle_options(self):
-        self.fake("mail")
         other_email = self.application.make("mail").mailable(Other())
         other_email.send().seeEmailFrom("no-reply@masonite.com")

--- a/tests/features/mail/test_mock_mail.py
+++ b/tests/features/mail/test_mock_mail.py
@@ -13,6 +13,16 @@ class Welcome(Mailable):
         )
 
 
+class Other(Mailable):
+    def build(self):
+        return (
+            self.to("idmann509@gmail.com")
+            .subject("Masonite 4")
+            .text("text from Masonite!")
+            .html("<h1>Hello from Masonite!</h1>")
+        )
+
+
 class TestSMTPDriver(TestCase):
     def setUp(self):
         super().setUp()
@@ -40,3 +50,8 @@ class TestSMTPDriver(TestCase):
         self.fake("mail")
         welcome_email = self.application.make("mail").mailable(Welcome())
         (welcome_email.seeEmailWasNotSent().send().seeEmailWasSent())
+
+    def test_mock_can_also_handle_options(self):
+        self.fake("mail")
+        other_email = self.application.make("mail").mailable(Other())
+        other_email.send().seeEmailFrom("no-reply@masonite.com")

--- a/tests/features/mail/test_smtp_driver.py
+++ b/tests/features/mail/test_smtp_driver.py
@@ -1,6 +1,7 @@
+import pytest
+
 from tests import TestCase
 from src.masonite.mail import Mailable
-import pytest
 
 
 class Welcome(Mailable):
@@ -18,4 +19,5 @@ class Welcome(Mailable):
 @pytest.mark.integrations
 class TestSMTPDriver(TestCase):
     def test_send_mailable(self):
-        self.application.make("mail").mailable(Welcome()).send(driver="terminal")
+        with self.assertRaises(ConnectionRefusedError):
+            self.application.make("mail").mailable(Welcome()).send(driver="smtp")

--- a/tests/features/mail/test_terminal.py
+++ b/tests/features/mail/test_terminal.py
@@ -18,7 +18,6 @@ class Other(Mailable):
         return (
             self.to("idmann509@gmail.com")
             .subject("Other")
-            .from_("joe@masoniteproject.com")
             .text("Hello from Masonite!")
             .html("<h1>Hello from Masonite!</h1>")
             .driver("terminal")
@@ -30,8 +29,18 @@ class TestTerminalDriver(TestCase):
         self.application.make("mail").mailable(
             Welcome().attach("invoice", "tests/integrations/storage/invoice.pdf")
         ).send(driver="terminal")
+        # TODO: once PR #560 merged add
+        # self.assertConsoleOutputContains("From: joe@masoniteproject.com")
+        # self.assertConsoleOutputContains("To: idmann509@gmail.com")
+        # self.assertConsoleOutputContains("Subject: Masonite 4")
+        # self.assertConsoleOutputContains("Attachment 0: invoice")
 
     def test_define_driver_with_mailable(self):
         self.application.make("mail").mailable(
             Other().attach("invoice", "tests/integrations/storage/invoice.pdf")
         ).send()
+        # TODO: once PR #560 merged add
+        # self.assertConsoleOutputContains("From: no-reply@masonite.com")
+        # self.assertConsoleOutputContains("To: idmann509@gmail.com")
+        # self.assertConsoleOutputContains("Subject: Other")
+        # self.assertConsoleOutputContains("Attachment 0: invoice")

--- a/tests/features/notification/test_mail_driver.py
+++ b/tests/features/notification/test_mail_driver.py
@@ -75,3 +75,4 @@ class TestMailDriver(TestCase):
         mail = self.fake("mail")
         self.notification.route("mail", "test@mail.com").send(CustomNotification())
         mail.seeDriverWas("mailgun")
+        self.restore("mail")

--- a/tests/integrations/config/mail.py
+++ b/tests/integrations/config/mail.py
@@ -7,7 +7,7 @@ DRIVERS = {
     "default": env("MAIL_DRIVER", "terminal"),
     "smtp": {
         "host": env("MAIL_HOST"),
-        "port": env("MAIL_PORT"),
+        "port": env("MAIL_PORT", "587"),
         "username": env("MAIL_USERNAME"),
         "password": env("MAIL_PASSWORD"),
         "from": FROM_EMAIL,

--- a/tests/integrations/config/mail.py
+++ b/tests/integrations/config/mail.py
@@ -1,16 +1,23 @@
-import os
+from masonite.environment import env
 
+
+FROM_EMAIL = env("MAIL_FROM", "no-reply@masonite.com")
 
 DRIVERS = {
-    "default": "smtp",
+    "default": env("MAIL_DRIVER", "terminal"),
     "smtp": {
-        "host": os.getenv("MAIL_HOST"),
-        "port": os.getenv("MAIL_PORT"),
-        "username": os.getenv("MAIL_USERNAME"),
-        "password": os.getenv("MAIL_PASSWORD"),
+        "host": env("MAIL_HOST"),
+        "port": env("MAIL_PORT"),
+        "username": env("MAIL_USERNAME"),
+        "password": env("MAIL_PASSWORD"),
+        "from": FROM_EMAIL,
     },
     "mailgun": {
-        "domain": os.getenv("MAILGUN_DOMAIN"),
-        "secret": os.getenv("MAILGUN_SECRET"),
+        "domain": env("MAILGUN_DOMAIN"),
+        "secret": env("MAILGUN_SECRET"),
+        "from": FROM_EMAIL,
+    },
+    "terminal": {
+        "from": FROM_EMAIL,
     },
 }


### PR DESCRIPTION
Fix #558.

The issue is that mailable `from` option is always overriding from options defined for the selected driver in `config/mail.py`. 
So when no from options is given in the mailable, the value of from is "" and the default option from the selected driver cannot be used.

In addition to this, MockMail was not provided with the mail configuration at initialization and the mail config of the test project was not up to date. This has been updated accordingly.

Tests have been improved a bit to do more real testing, e.g. SMTP and Mailgun drivers are really tested (still as an integration test) and their error handled. At least we can really test sending the email even if no credentials were provided.