### PR TITLE
Fix deprecation warning for `distutils` module in craft `auth` command

### DIFF
--- a/src/masonite/commands/AuthCommand.py
+++ b/src/masonite/commands/AuthCommand.py
@@ -1,5 +1,5 @@
 """Scaffold Auth Command."""
-from distutils.dir_util import copy_tree
+from shutil import copytree
 import os
 
 from ..utils.location import controllers_path, views_path, mailables_path
@@ -19,13 +19,13 @@ class AuthCommand(Command):
         self.app = application
 
     def handle(self):
-        copy_tree(
+        copytree(
             self.get_template_path(),
             views_path("auth"),
         )
-        copy_tree(self.get_controllers_path(), controllers_path("auth"))
+        copytree(self.get_controllers_path(), controllers_path("auth"))
 
-        copy_tree(self.mailables_path(), mailables_path())
+        copytree(self.mailables_path(), mailables_path())
 
         self.info("Auth scaffolded successfully!")
 

--- a/src/masonite/commands/AuthCommand.py
+++ b/src/masonite/commands/AuthCommand.py
@@ -1,6 +1,7 @@
 """Scaffold Auth Command."""
 from shutil import copytree
 import os
+import sys
 
 from ..utils.location import controllers_path, views_path, mailables_path
 from ..utils.filesystem import get_module_dir
@@ -19,13 +20,21 @@ class AuthCommand(Command):
         self.app = application
 
     def handle(self):
-        copytree(
-            self.get_template_path(),
-            views_path("auth"),
-        )
-        copytree(self.get_controllers_path(), controllers_path("auth"))
+        # dirs_exist_ok option is available in Python 3.8+
+        # https://docs.python.org/3/library/shutil.html#shutil.copytree
+        if sys.version_info.minor >= 8:
+            copytree(self.get_template_path(), views_path("auth"), dirs_exist_ok=True)
+            copytree(
+                self.get_controllers_path(),
+                controllers_path("auth"),
+                dirs_exist_ok=True,
+            )
 
-        copytree(self.mailables_path(), mailables_path())
+            copytree(self.mailables_path(), mailables_path(), dirs_exist_ok=True)
+        else:
+            copytree(self.get_template_path(), views_path("auth"))
+            copytree(self.get_controllers_path(), controllers_path("auth"))
+            copytree(self.mailables_path(), mailables_path())
 
         self.info("Auth scaffolded successfully!")
 


### PR DESCRIPTION
Fix #562.

Old `copy_tree` method doc:
https://docs.python.org/3/distutils/apiref.html#distutils.dir_util.copy_tree

New `copytree` method doc:
https://docs.python.org/3/library/shutil.html#shutil.copytree

The new method will complain if directory already exists when the old method was not complaining. To keep same behaviour we need to add, `dirs_exists_ok=True` argument to allow overriding. But this option is only available starting from Python 3.8. As Masonite is compatible with Python 3.7, we need to handle this case (this switch will be removed when 3.7 will be dropped by Masonite one day).

I am not a big fan of switches but here it's not that much of a problem IMO.
 