### PR TITLE
fixed command capsule to work on uwsgi

### DIFF
--- a/src/masonite/commands/CommandCapsule.py
+++ b/src/masonite/commands/CommandCapsule.py
@@ -2,10 +2,16 @@ class CommandCapsule:
     def __init__(self, command_application):
         self.command_application = command_application
         self.commands = []
+        self.command_name = []
 
     def add(self, *commands):
-        self.commands.append(commands)
-        self.command_application.add_commands(*commands)
+        for command in commands:
+            command_name = command.config.name
+            if command_name in self.command_name:
+                continue
+            self.command_name.append(command_name)
+            self.commands.append(command)
+            self.command_application.add_commands(command)
         return self
 
     def swap(self, command):


### PR DESCRIPTION
was having an issue running Masonite on uwsgi kept saying the commands already exist. I think it was running the container twice on boot somehow