### PR TITLE
Fix query string use

### DIFF
--- a/src/masonite/request/request.py
+++ b/src/masonite/request/request.py
@@ -50,7 +50,11 @@ class Request(ValidatesRequest, AuthorizesRequest):
         return self.environ.get("PATH_INFO")
 
     def get_path_with_query(self):
-        return self.environ.get("PATH_INFO") + "?" + self.environ.get("QUERY_STRING")
+        query_string = self.environ.get("QUERY_STRING")
+        if query_string:
+            return self.get_path() + "?" + query_string
+        else:
+            return self.get_path()
 
     def get_back_path(self):
         return self.input("__back") or self.get_path_with_query()

--- a/src/masonite/utils/http.py
+++ b/src/masonite/utils/http.py
@@ -66,7 +66,7 @@ HTTP_STATUS_CODES = {
 }
 
 
-def generate_wsgi(wsgi={}, path="/", query_string="application=Masonite", method="GET"):
+def generate_wsgi(wsgi={}, path="/", query_string="", method="GET"):
     """Generate the WSGI environment dictionary that we receive from a HTTP request."""
     import io
 


### PR DESCRIPTION
- When getting full request path with query parameters, if there are no params then the request is `/test?` when it should be `/test`.
- Also when using `generate_wsgi()` to generate WSGI for making a request (e.g. in tests), no query parameters should be added by default. So I set `query_string` default value as `""`.
