### PR TITLE
Add ability to pass query parameters to `url` and `route` helpers and to `redirect` method

### DIFF
--- a/src/masonite/helpers/urls.py
+++ b/src/masonite/helpers/urls.py
@@ -1,4 +1,6 @@
 from os.path import join
+from urllib import parse
+
 from ..configuration import config
 
 
@@ -8,11 +10,23 @@ class UrlsHelper:
     def __init__(self, app):
         self.app = app
 
-    def url(self, path=""):
+    def url(self, path: str = "", query_params: dict = {}) -> str:
         """Generates a fully qualified url to the given path. If no path is given this will return
-        the base url domain."""
+        the base url domain. A query parameters dictionary can be provided to add query parameters
+        to the url."""
         # ensure that no slash is prefixing the relative path
-        relative_path = path.lstrip("/")
+        path_result = parse.urlsplit(path.lstrip("/"))
+
+        # parse existing query parameters
+        existing_query_params = dict(parse.parse_qsl(path_result.query))
+        all_query_params = {**existing_query_params, **query_params}
+
+        relative_path = path_result.path
+
+        # add query parameters to url if any
+        if all_query_params:
+            relative_path += "?" + parse.urlencode(all_query_params)
+
         return join(config("application.app_url"), relative_path)
 
     def asset(self, alias, filename):

--- a/src/masonite/helpers/urls.py
+++ b/src/masonite/helpers/urls.py
@@ -48,15 +48,19 @@ class UrlsHelper:
                 location = list(location.values())[0]
         return join(location, filename)
 
-    def route(self, name, params={}, absolute=True):
+    def route(
+        self, name: str, params: dict = {}, absolute=True, query_params: dict = {}
+    ) -> str:
         """Generates a fully qualified URL to the given route name.
         Example:
             route("users.home") : http://masonite.app/dashboard/
             route("users.profile", {"id": 1}) : http://masonite.app/users/1/profile/
+            route("users.profile", {"id": 1}, query_params={"section": "infos"}) :
+                http://masonite.app/users/1/profile/?section=info
             route("users.profile", {"id": 1}, absolute=False) : /users/1/profile/
         """
 
-        relative_url = self.app.make("router").route(name, params)
+        relative_url = self.app.make("router").route(name, params, query_params)
         if absolute:
             return self.url(relative_url)
         else:

--- a/src/masonite/helpers/urls.py
+++ b/src/masonite/helpers/urls.py
@@ -1,6 +1,6 @@
 from os.path import join
-from urllib import parse
 
+from ..utils.str import add_query_params
 from ..configuration import config
 
 
@@ -15,18 +15,12 @@ class UrlsHelper:
         the base url domain. A query parameters dictionary can be provided to add query parameters
         to the url."""
         # ensure that no slash is prefixing the relative path
-        path_result = parse.urlsplit(path.lstrip("/"))
+        relative_path = path.lstrip("/")
 
-        # parse existing query parameters
-        existing_query_params = dict(parse.parse_qsl(path_result.query))
-        all_query_params = {**existing_query_params, **query_params}
+        # add query params if any
+        relative_path = add_query_params(relative_path, query_params)
 
-        relative_path = path_result.path
-
-        # add query parameters to url if any
-        if all_query_params:
-            relative_path += "?" + parse.urlencode(all_query_params)
-
+        # fully qualify the url
         return join(config("application.app_url"), relative_path)
 
     def asset(self, alias, filename):

--- a/src/masonite/routes/HTTPRoute.py
+++ b/src/masonite/routes/HTTPRoute.py
@@ -1,5 +1,5 @@
 import re
-import os
+from urllib import parse
 
 from ..utils.str import modularize, removeprefix
 from ..exceptions import InvalidRouteCompileException
@@ -72,7 +72,8 @@ class HTTPRoute:
         self._domain = subdomain
         return self
 
-    def to_url(self, parameters={}):
+    def to_url(self, parameters: dict = {}, query_params: dict = {}) -> str:
+        """Transform route to a URL string with the given url and query parameters."""
 
         # Split the url into a list
         split_url = self.url.split("/")
@@ -107,6 +108,9 @@ class HTTPRoute:
         if "//" in compiled_url:
             compiled_url = compiled_url.replace("//", "/")
 
+        # Add eventual query parameters
+        if query_params:
+            compiled_url += "?" + parse.urlencode(query_params)
         return compiled_url
 
     def _find_controller(self, controller):

--- a/src/masonite/routes/Router.py
+++ b/src/masonite/routes/Router.py
@@ -1,3 +1,4 @@
+from urllib import parse
 from ..utils.collections import flatten
 from ..exceptions import RouteNotFoundException
 
@@ -43,7 +44,7 @@ class Router:
         self.routes = flatten(self.routes)
 
     @classmethod
-    def compile_to_url(cls, uncompiled_route, params={}):
+    def compile_to_url(cls, uncompiled_route, params={}, query_params={}):
         """Compile the route url into a usable url: converts /url/@id into /url/1.
         Used for redirection
 
@@ -51,6 +52,7 @@ class Router:
             route {string} -- An uncompiled route like (/dashboard/@user:string/@id:int)
         Keyword Arguments:
             params {dict} -- Dictionary of parameters to pass to the route (default: {{}})
+            query_params {dict} -- Dictionary of query parameters to pass to the route (default: {{}})
         Returns:
             string -- Returns a compiled string (/dashboard/joseph/1)
         """
@@ -90,5 +92,9 @@ class Router:
         # The loop isn't perfect and may have 2 slashes next to eachother
         if "//" in compiled_url:
             compiled_url = compiled_url.replace("//", "/")
+
+        # Add eventual query parameters
+        if query_params:
+            compiled_url += "?" + parse.urlencode(query_params)
 
         return compiled_url

--- a/src/masonite/routes/Router.py
+++ b/src/masonite/routes/Router.py
@@ -22,10 +22,11 @@ class Router:
             if route.match_name(name):
                 return route
 
-    def route(self, name, parameters={}):
+    def route(self, name: str, parameters: dict = {}, query_params: dict = {}) -> str:
+        """Return URL string from given route name and parameters."""
         route = self.find_by_name(name)
         if route:
-            return route.to_url(parameters)
+            return route.to_url(parameters, query_params)
         raise RouteNotFoundException(f"Could not find route with the name '{name}'")
 
     def set_controller_locations(self, location):

--- a/src/masonite/utils/str.py
+++ b/src/masonite/utils/str.py
@@ -1,6 +1,7 @@
 """String generators and helpers"""
 import random
 import string
+from urllib import parse
 
 
 def random_string(length=4):
@@ -56,3 +57,20 @@ def removesuffix(string, suffix):
         return string[: -len(suffix)]
     else:
         return string
+
+
+def add_query_params(url: str, query_params: dict) -> str:
+    """Add query params dict to a given url (which can already contain some query parameters)."""
+    path_result = parse.urlsplit(url)
+
+    base_url = path_result.path
+
+    # parse existing query parameters if any
+    existing_query_params = dict(parse.parse_qsl(path_result.query))
+    all_query_params = {**existing_query_params, **query_params}
+
+    # add query parameters to url if any
+    if all_query_params:
+        base_url += "?" + parse.urlencode(all_query_params)
+
+    return base_url

--- a/tests/core/helpers/test_urls.py
+++ b/tests/core/helpers/test_urls.py
@@ -9,6 +9,26 @@ class TestUrlsHelper(TestCase):
         self.assertEqual(url.url("/about/us"), "http://localhost:8000/about/us")
         self.assertEqual(url.url(), "http://localhost:8000/")
 
+        # with query parameters
+        self.assertEqual(
+            url.url("search", {"q": "joe", "order": "asc"}),
+            "http://localhost:8000/search?q=joe&order=asc",
+        )
+        self.assertEqual(
+            url.url("search", {"q": "El Niño", "order": "asc"}),
+            "http://localhost:8000/search?q=El+Ni%C3%B1o&order=asc",
+        )
+
+        self.assertEqual(
+            url.url("search?q=joe", {"order": "asc"}),
+            "http://localhost:8000/search?q=joe&order=asc",
+        )
+
+        self.assertEqual(
+            url.url("/users/search?q=joe", {"q": "john doe", "debug": 1}),
+            "http://localhost:8000/users/search?q=john+doe&debug=1",
+        )
+
     def test_route(self):
         self.assertEqual(url.route("welcome"), "http://localhost:8000/")
         self.assertEqual(

--- a/tests/core/helpers/test_urls.py
+++ b/tests/core/helpers/test_urls.py
@@ -36,6 +36,11 @@ class TestUrlsHelper(TestCase):
         )
         self.assertEqual(url.route("upload"), "http://localhost:8000/upload")
         self.assertEqual(url.route("upload", absolute=False), "/upload")
+        # with query parameters
+        self.assertEqual(
+            url.route("upload", query_params={"force": 1}),
+            "http://localhost:8000/upload?force=1",
+        )
 
     def test_asset(self):
         self.assertTrue(

--- a/tests/core/response/test_response_redirections.py
+++ b/tests/core/response/test_response_redirections.py
@@ -1,8 +1,6 @@
 from tests import TestCase
-from src.masonite.foundation import Application
-import os
 from src.masonite.response import Response
-from src.masonite.routes import Router, Route
+from src.masonite.routes import Route
 
 
 class TestResponseRedirect(TestCase):
@@ -16,12 +14,23 @@ class TestResponseRedirect(TestCase):
         self.assertEqual(self.response.get_status(), 302)
         self.assertEqual(self.response.header_bag.get("Location").value, "/")
 
+        self.response.redirect("/", query_params={"key": "value"})
+        self.assertEqual(self.response.header_bag.get("Location").value, "/?key=value")
+
     def test_redirect_to_route_named_route(self):
         self.response.redirect(name="home-redirect")
         self.assertEqual(self.response.get_status(), 302)
         self.assertEqual(self.response.header_bag.get("Location").value, "/")
 
+        self.response.redirect(name="home-redirect", query_params={"key": "value"})
+        self.assertEqual(self.response.header_bag.get("Location").value, "/?key=value")
+
     def test_redirect_to_url(self):
         self.response.redirect(url="/login")
         self.assertEqual(self.response.get_status(), 302)
         self.assertEqual(self.response.header_bag.get("Location").value, "/login")
+
+        self.response.redirect(url="/login", query_params={"key": "value"})
+        self.assertEqual(
+            self.response.header_bag.get("Location").value, "/login?key=value"
+        )

--- a/tests/routes/test_routes.py
+++ b/tests/routes/test_routes.py
@@ -50,6 +50,10 @@ class TestRoutes(TestCase):
         url = router.route("dashboard", [2, 1])
         self.assertEqual(url, "/dashboard/2/1")
 
+        # with query parameters
+        url = router.route("home", {"id": 1}, query_params={"preview": "true"})
+        self.assertEqual(url, "/home/1?preview=true")
+
     def test_can_find_route_optional_params(self):
         router = Router(Route.get("/home/?id", "WelcomeController"))
 


### PR DESCRIPTION
Fix #574 

This PR adds the ability to provide URL query parameters to URL helpers, route and redirect methods. This is handy, to avoid concatenate those yourself. Query parameters should be provided as a dictionary.

```python
# url helper
from masonite.helpers import url

url.url("/search/users",  query_params={"search": "John Doe" "order": "asc"})
#== http://masonite.app/users/?search=John%2Doe&order=asc

# route helper
from masonite.helpers import url

url.route("home",  query_params={"preview": 1})
# == /home?preview=1

# redirects
response.redirect("/home", query_params={"key": "value"})
response.redirect(url="/home", query_params={"key": "value"})
response.redirect(name="home", query_params={"key": "value"})
#== will redirect to /home?key=value
```