### PR TITLE
Add more config options to AMQP driver

### DIFF
--- a/src/masonite/drivers/queue/AMQPDriver.py
+++ b/src/masonite/drivers/queue/AMQPDriver.py
@@ -42,7 +42,7 @@ class AMQPDriver(HasColoredOutput):
     def publish(self, payload):
         pika = self.get_package_library()
         self.publishing_channel.basic_publish(
-            exchange="",
+            exchange=self.options.get("exchange"),
             routing_key=self.options.get("queue"),
             body=pickle.dumps(payload),
             properties=pika.BasicProperties(

--- a/src/masonite/drivers/queue/AMQPDriver.py
+++ b/src/masonite/drivers/queue/AMQPDriver.py
@@ -1,6 +1,8 @@
 import pickle
 import pendulum
 import inspect
+from urllib import parse
+
 from ...utils.console import HasColoredOutput
 
 
@@ -67,20 +69,18 @@ class AMQPDriver(HasColoredOutput):
             raise ModuleNotFoundError(
                 "Could not find the 'pika' library. Run 'pip install pika' to fix this."
             )
-
-        self.connection = pika.BlockingConnection(
-            pika.URLParameters(
-                "amqp://{}:{}@{}{}/{}".format(
-                    self.options.get("username"),
-                    self.options.get("password"),
-                    self.options.get("host"),
-                    ":" + str(self.options.get("port"))
-                    if self.options.get("port")
-                    else "",
-                    self.options.get("vhost", "%2F"),
-                )
-            )
+        connection_url = "amqp://{}:{}@{}{}/{}".format(
+            self.options.get("username"),
+            self.options.get("password"),
+            self.options.get("host"),
+            ":" + str(self.options.get("port")) if self.options.get("port") else "",
+            self.options.get("vhost", "%2F"),
         )
+        if self.options.get("connection_options"):
+            connection_url += "?" + parse.urlencode(
+                self.options.get("connection_options")
+            )
+        self.connection = pika.BlockingConnection(pika.URLParameters(connection_url))
 
         self.publishing_channel = self.connection.channel()
 

--- a/tests/integrations/config/queue.py
+++ b/tests/integrations/config/queue.py
@@ -11,20 +11,19 @@ DRIVERS = {
     "redis": {
         #
     },
-    # See https://pika.readthedocs.io/en/stable/modules/parameters.html#pika.connection.URLParameters
-    # for valid connection options values
     "amqp": {
         "username": "guest",
         "password": "guest",
         "port": "5672",
         "vhost": "",
         "host": "localhost",
-        "exchange": "",
+        # See https://pika.readthedocs.io/en/stable/modules/parameters.html#pika.connection.URLParameters
+        # for valid connection options values
         "connection_options": {},
+        "exchange": "",
         "channel": "default",
         "queue": "masonite4",
         "tz": "UTC",
-        "exchange": "",
     },
     "async": {
         "blocking": True,

--- a/tests/integrations/config/queue.py
+++ b/tests/integrations/config/queue.py
@@ -19,6 +19,7 @@ DRIVERS = {
         "port": "5672",
         "vhost": "",
         "host": "localhost",
+        "exchange": "",
         "connection_options": {},
         "channel": "default",
         "queue": "masonite4",

--- a/tests/integrations/config/queue.py
+++ b/tests/integrations/config/queue.py
@@ -11,15 +11,19 @@ DRIVERS = {
     "redis": {
         #
     },
+    # See https://pika.readthedocs.io/en/stable/modules/parameters.html#pika.connection.URLParameters
+    # for valid connection options values
     "amqp": {
         "username": "guest",
         "password": "guest",
         "port": "5672",
         "vhost": "",
         "host": "localhost",
+        "connection_options": {},
         "channel": "default",
         "queue": "masonite4",
         "tz": "UTC",
+        "exchange": "",
     },
     "async": {
         "blocking": True,


### PR DESCRIPTION
Fix #572

This PR adds:
- the `exchange` option to publish message
- all the query string connection options that are defined [here](https://pika.readthedocs.io/en/stable/modules/parameters.html#pika.connection.URLParameters) through the `connection_options` key

Those new options must be added to the project template too 👉 https://github.com/MasoniteFramework/cookie-cutter/pull/39