### PR TITLE
Fix `optional` helper

### DIFF
--- a/src/masonite/helpers/optional.py
+++ b/src/masonite/helpers/optional.py
@@ -1,18 +1,26 @@
 class DefaultType:
-    def __init__(self, value):
+    def __init__(self, value, obj):
         self.value = value
+        self.obj = obj
+
+    def default(self):
+        if callable(self.value):
+            return self.value(self.obj)
+        else:
+            return self.value
 
     def __getattr__(self, attr):
-        return self.value
+        return self.default()
 
     def __call__(self, *args, **kwargs):
-        return self.value
+        return self.default()
 
     def __eq__(self, other):
-        if self.value is None:
-            return other is self.value
+        value = self.default()
+        if value is None:
+            return other is value
         else:
-            return other == self.value
+            return other == value
 
 
 class Optional:
@@ -26,10 +34,10 @@ class Optional:
     def __getattr__(self, attr):
         if hasattr(self.obj, attr):
             return getattr(self.obj, attr)
-        return DefaultType(self.default)
+        return DefaultType(self.default, self.obj)()
 
     def __call__(self, *args, **kwargs):
-        return DefaultType(self.default)
+        return DefaultType(self.default, self.obj)()
 
     def instance(self):
         return self.obj

--- a/tests/core/helpers/test_optional.py
+++ b/tests/core/helpers/test_optional.py
@@ -14,15 +14,24 @@ class SomeClass:
 class TestOptionalHelper(TestCase):
     def test_optional_with_existing(self):
         obj = SomeClass()
-        self.assertEqual(optional(obj).my_attr, 3)
-        self.assertEqual(optional(obj).my_method(), 4)
+        assert optional(obj).my_attr == 3
+        assert optional(obj).my_method() == 4
 
     def test_optional_with_undefined(self):
         obj = SomeClass()
-        self.assertEqual(optional(obj).non_existing_attr, None)
-        self.assertEqual(optional(obj).non_existing_method(), None)
+        assert optional(obj).non_existing_attr is None
+
+        # not beautiful but we can do this to handle calling methods
+        assert optional(optional(obj).non_existing_method)() is None
+
+    def test_optional_with_undefined_on_none(self):
+        obj = None
+        assert optional(obj).non_existing_attr is None
 
     def test_optional_with_default(self):
         obj = SomeClass()
-        self.assertEqual(optional(obj, default=0).non_existing_attr, 0)
-        self.assertEqual(optional(obj, default=0).non_existing_method(), 0)
+        assert optional(obj, 0).non_existing_attr == 0
+
+    def test_optional_with_callable_default(self):
+        obj = SomeClass()
+        assert optional(obj, lambda the_obj: "a").non_existing_attr == "a"


### PR DESCRIPTION
The `optional` helper is not working.

We really can't by design in Python be able to anticipate if an unexisting attribute on such an object will be accessed by in a callable way or not.

So this helper can only solve this problem:

```python
request.user() #== None, because we are not authenticated
name = optional(request.user()).name #== None and no attribute error is raised
```

not this one:
```python
request.user() #== None
optional(request.user()).send_email() 
```

So this PR fixes this to only try to implement the first feature, for now tests were passing and equivalences were ok but the real value returned by the helper was not `None` (or the default value) but an instance of `DefaultType` class so that was not good 👎 .

Also the default value can now be a callable that will be given the object itself.