### PR TITLE
Fixed ExceptionHandler

### DIFF
--- a/src/masonite/exceptions/ExceptionHandler.py
+++ b/src/masonite/exceptions/ExceptionHandler.py
@@ -35,31 +35,32 @@ class ExceptionHandler:
             f"masonite.exception.{exception.__class__.__name__}", exception
         )
 
+        # if an exception handler is registered for this exception, use it instead
         if self.application.has(f"{exception.__class__.__name__}Handler"):
             return self.application.make(
                 f"{exception.__class__.__name__}Handler"
             ).handle(exception)
 
-        exceptionite = self.get_driver("exceptionite")
-
-        if "application/json" in str(request.header("Accept")):
-            exceptionite.start(exception)
-            return response.view(exceptionite.render("json"), status=500)
-
+        # handle exception in production
         if not self.application.is_debug():
             # for HTTP error codes (500, 404, 403...) a specific page should be displayed
-            if hasattr(exception, "is_http_exception"):
-                return self.application.make("HttpExceptionHandler").handle(exception)
             # if a renderable exception is raised let it be displayed
-            if hasattr(exception, "get_response"):
-                return response.view(exception.get_response(), exception.get_status())
+            if hasattr(exception, "is_http_exception") or hasattr(
+                exception, "get_response"
+            ):
+                return self.application.make("HttpExceptionHandler").handle(exception)
 
-            # else fallback to an unknown exception should be displayed as a 500 error
+            # else fallback to an unknown exception that should be displayed as a 500 error
             exception.get_status = lambda: 500
             exception.get_response = lambda: str(exception) or "Unknown error"
             return self.application.make("HttpExceptionHandler").handle(exception)
 
-        # else display exceptionite error page
+        # handle exception in development mode with Exceptionite
+        exceptionite = self.get_driver("exceptionite")
         exceptionite.start(exception)
         exceptionite.render("terminal")
-        return response.view(exceptionite.render("web"), status=500)
+
+        if request.accepts_json():
+            return response.view(exceptionite.render("json"), status=500)
+        else:
+            return response.view(exceptionite.render("web"), status=500)

--- a/src/masonite/exceptions/exceptionite/blocks.py
+++ b/src/masonite/exceptions/exceptionite/blocks.py
@@ -38,10 +38,14 @@ class AppBlock(Block):
 
         # add app route data
         if route:
+            if isinstance(route.controller, str):
+                controller = route.controller
+            else:
+                controller = route.controller.__qualname__
             data.update(
                 {
                     "Route": {
-                        "Controller": route.controller,
+                        "Controller": controller,
                         "Name": route.get_name(),
                         "Middlewares": route.get_middlewares(),
                     }

--- a/src/masonite/exceptions/handlers/HttpExceptionHandler.py
+++ b/src/masonite/exceptions/handlers/HttpExceptionHandler.py
@@ -6,6 +6,16 @@ class HttpExceptionHandler:
         status_code = exception.get_status()
         view_name = f"errors/{status_code}"
         response = self.application.make("response")
+        request = self.application.make("request")
+
+        if request.accepts_json():
+            payload = {
+                "status": exception.get_status(),
+                "message": exception.get_response(),
+            }
+            return response.json(payload, status_code)
+
+        # Renders HTTP exception as HTML with predefined error page if exists
         if self.application.make("view").exists(view_name):
             return response.view(
                 self.application.make("view").render(
@@ -14,4 +24,5 @@ class HttpExceptionHandler:
                 status_code,
             )
         else:
+            # Else render the exception without using template
             return response.view(exception.get_response(), status_code)

--- a/src/masonite/request/request.py
+++ b/src/masonite/request/request.py
@@ -174,3 +174,7 @@ class Request(ValidatesRequest, AuthorizesRequest):
     def ip(self) -> "str|None":
         """Return the request IP by processing the different headers setup in IpMiddleware."""
         return self._ip
+
+    def accepts_json(self) -> bool:
+        """Check if request Accept header contains application/json."""
+        return "application/json" in str(self.header("Accept"))

--- a/tests/core/exceptions/test_exception_handler.py
+++ b/tests/core/exceptions/test_exception_handler.py
@@ -1,0 +1,95 @@
+import pytest
+
+from tests import TestCase
+from src.masonite.routes import Route
+from src.masonite.controllers import Controller
+from src.masonite.exceptions import RouteNotFoundException
+
+
+class TestController(Controller):
+    def simple(self):
+        1 / 0
+
+    def http(self):
+        raise RouteNotFoundException()
+
+
+class TestExceptionHandlerInDebug(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.handler = self.application.make("exception_handler")
+        self.setRoutes(
+            Route.get("/simple", TestController.simple),
+            Route.get("/http", TestController.http),
+        )
+        # enable exceptions handling during all the tests of this class
+        # because it is what is tested here
+        self.withExceptionsHandling()
+
+    def test_that_exception_event_is_fired(self):
+        # with self.debugMode():
+        #     self.get("/simple")
+        pass
+
+    def test_raising_simple_exception_renders_debug_error_page(self):
+        with self.debugMode():
+            self.get("/simple").assertError().assertContains(
+                "ZeroDivisionError"
+            ).assertContains("Exceptionite")
+
+    def test_raising_http_exception_renders_debug_error_page(self):
+        with self.debugMode():
+            self.get("/http").assertError().assertContains(
+                "RouteNotFoundException"
+            ).assertContains("Exceptionite")
+
+    def test_raising_exception_output_stack_trace_to_console(self):
+        with self.debugMode():
+            self.get("/simple")
+            self.assertConsoleOutputContains(
+                "ZeroDivisionError: division by zero"
+            ).assertConsoleOutputContains("Stack Trace")
+
+    @pytest.mark.skip("Waiting for PR #579 to be merged")
+    def test_accepting_json_returns_debug_error_payload(self):
+        with self.debugMode():
+            self.withHeaders({"Accept": "application/json"}).get(
+                "/simple"
+            ).assertError().assertJsonPath(
+                "exception.type", "RouteNotFoundException"
+            ).assertJsonPath(
+                "stacktrace"
+            )
+
+
+class TestExceptionHandler(TestCase):
+    """Test error handling in production mode, debug is False."""
+
+    def setUp(self):
+        super().setUp()
+        self.handler = self.application.make("exception_handler")
+        self.setRoutes(Route.get("/simple", TestController.simple))
+        # enable exceptions handling during all the tests of this class
+        # because it is what is tested here
+        self.withExceptionsHandling()
+
+    def test_that_exception_event_is_fired(self):
+        pass
+
+    def test_raising_simple_exception_renders_500_error_template(self):
+        self.get("/simple").assertError().assertContains("Error 500")
+
+    def test_raising_http_exception_renders_404_error_page(self):
+        self.get("/http").assertNotFound().assertContains("Page Not Found")
+
+    def test_raising_exception_does_not_output_stack_trace_to_console(self):
+        self.get("/simple")
+        self.assertConsoleEmpty()
+
+    @pytest.mark.skip("Waiting for PR #579 to be merged")
+    def test_accepting_json_returns_500_error_payload(self):
+        self.withHeaders({"Accept": "application/json"}).get(
+            "/simple"
+        ).assertError().assertJson(
+            {"status": 500, "message": "GET /simple: division by zero"}
+        )

--- a/tests/core/exceptions/test_exception_handler.py
+++ b/tests/core/exceptions/test_exception_handler.py
@@ -77,19 +77,23 @@ class TestExceptionHandler(TestCase):
         pass
 
     def test_raising_simple_exception_renders_500_error_template(self):
-        self.get("/simple").assertError().assertContains("Error 500")
+        with self.debugMode(False):
+            self.get("/simple").assertError().assertContains("Error 500")
 
     def test_raising_http_exception_renders_404_error_page(self):
-        self.get("/http").assertNotFound().assertContains("Page Not Found")
+        with self.debugMode(False):
+            self.get("/http").assertNotFound().assertContains("Page Not Found")
 
     def test_raising_exception_does_not_output_stack_trace_to_console(self):
-        self.get("/simple")
-        self.assertConsoleEmpty()
+        with self.debugMode(False):
+            self.get("/simple")
+            self.assertConsoleEmpty()
 
     @pytest.mark.skip("Waiting for PR #579 to be merged")
     def test_accepting_json_returns_500_error_payload(self):
-        self.withHeaders({"Accept": "application/json"}).get(
-            "/simple"
-        ).assertError().assertJson(
-            {"status": 500, "message": "GET /simple: division by zero"}
-        )
+        with self.debugMode(False):
+            self.withHeaders({"Accept": "application/json"}).get(
+                "/simple"
+            ).assertError().assertJson(
+                {"status": 500, "message": "GET /simple: division by zero"}
+            )

--- a/tests/core/request/test_request.py
+++ b/tests/core/request/test_request.py
@@ -44,3 +44,9 @@ class TestRequest(TestCase):
         )
         request = IpMiddleware().before(request, response)
         self.assertEqual(request.ip(), "127.0.0.1")
+
+    def test_requests_accepts_json(self):
+        request = self.make_request({"HTTP_ACCEPT": "application/json"})
+        self.assertTrue(request.accepts_json())
+        request = self.make_request({"HTTP_ACCEPT": "text/html"})
+        self.assertFalse(request.accepts_json())


### PR DESCRIPTION
Fix #582 

- Fixed exceptionite page error when controller is not a string but imported directly in the route
- Update the exception handling lifecycle to:
  - send error as JSON when request accepts JSON in debug mode or not (in debug mode it will use exceptionite JSONRenderer else it will send a small payload with status and message)
  - send debug error page when request is normal and debug mode is true
  - send HTML default error page if found or send custom error page depending on exception
