### PR TITLE
Fixed `dd` and `dump` helpers which were not dumping into console

### DIFF
--- a/src/masonite/dumps/Dump.py
+++ b/src/masonite/dumps/Dump.py
@@ -1,5 +1,10 @@
 import time
 import inspect
+from pprint import pformat
+
+
+def color(string):
+    return f"\033[93m{string}\033[0m"
 
 
 def is_property(obj):
@@ -74,6 +79,12 @@ class Dump:
         return self._format()
 
     def _format(self):
-        return f"""DUMP -> {self.filename}: {self.line} in {self.method}()
-        {self.objects}
-        """
+        """Format the dump as string to be printed in console."""
+        output = f"\n{color('>>> DUMP')} from {self.filename}: {color(f'L{self.line}')} in {color(f'{self.method}()')}"
+
+        for name, obj in self.objects.items():
+            output += f"\n\n{color(f'  - {name}:')}\n"
+            output += f"  {pformat(obj, width=110, indent=4)}"
+
+        output += color("\n\n<<< END")
+        return output

--- a/src/masonite/dumps/Dumper.py
+++ b/src/masonite/dumps/Dumper.py
@@ -21,7 +21,11 @@ class Dumper:
 
     def dump(self, *objects):
         """Dump all provided args and continue code execution. This does not raise a DumpException."""
-        return self._dump(*objects)
+        dumps = self._dump(*objects)
+        # output dumps in console
+        for dump in dumps:
+            print(dump)
+        return dumps
 
     def get_dumps(self, ascending=False):
         """Get all dumps as Dump objects."""

--- a/tests/features/dumps/test_dump_exception_handler.py
+++ b/tests/features/dumps/test_dump_exception_handler.py
@@ -20,3 +20,6 @@ class TestDumpExceptionHandler(TestCase):
         self.get("/dd").assertOk().assertViewHas("dumps").assertContains(
             "dump and die : 2 dumps"
         ).assertContains("request").assertContains("test")
+
+        self.assertConsoleOutputContains(">>> DUMP")
+        self.assertConsoleOutputContains("test")

--- a/tests/features/dumps/test_dumper.py
+++ b/tests/features/dumps/test_dumper.py
@@ -107,3 +107,9 @@ class TestDumper(TestCase):
         var = "test"
         dump(var)
         assert self.dumper.last().objects.get("var") == "test"
+
+    def test_dump_output_data_in_console(self):
+        var = "test"
+        dump(var)
+        self.assertConsoleOutputContains(">>> DUMP")
+        self.assertConsoleOutputContains("test")


### PR DESCRIPTION
This PR fixes dump feature to dump data into console when using `dd` and `dump` as for now it was only displaying the dump page on `dd` in debug mode.

Fix #584

Here is how it renders into the console when doing `dump(request, view, test)`

![image](https://user-images.githubusercontent.com/9897999/163399160-c6cda015-c72d-4730-a67e-e831078204b6.png)
