### PR TITLE
Fixed getting extension such as `.tar.gz` from files in filesystem feature

### DIFF
--- a/src/masonite/filesystem/File.py
+++ b/src/masonite/filesystem/File.py
@@ -1,5 +1,6 @@
 import hashlib
-import os
+
+from ..utils.filesystem import get_extension
 
 
 class File:
@@ -11,7 +12,7 @@ class File:
         pass
 
     def extension(self):
-        return os.path.splitext(self.filename)[1]
+        return get_extension(self.filename)
 
     def name(self):
         return self.filename

--- a/src/masonite/filesystem/FileStream.py
+++ b/src/masonite/filesystem/FileStream.py
@@ -1,5 +1,7 @@
 import os
 
+from ..utils.filesystem import get_extension
+
 
 class FileStream:
     def __init__(self, stream, name=None):
@@ -10,7 +12,7 @@ class FileStream:
         return self.stream.name
 
     def extension(self):
-        return os.path.splitext(self._name or self.path())[1]
+        return get_extension(self._name or self.path())
 
     def name(self):
         return self._name or os.path.basename(self.path())

--- a/src/masonite/filesystem/UploadedFile.py
+++ b/src/masonite/filesystem/UploadedFile.py
@@ -1,5 +1,6 @@
-import os
 import hashlib
+
+from ..utils.filesystem import get_extension
 
 
 class UploadedFile:
@@ -8,7 +9,7 @@ class UploadedFile:
         self.content = content
 
     def extension(self):
-        return os.path.splitext(self.filename)[1]
+        return get_extension(self.filename)
 
     @property
     def name(self):

--- a/src/masonite/filesystem/drivers/AmazonS3Driver.py
+++ b/src/masonite/filesystem/drivers/AmazonS3Driver.py
@@ -1,8 +1,8 @@
 import os
-from shutil import copyfile, move
+import uuid
+
 from ..FileStream import FileStream
 from ..File import File
-import uuid
 
 
 class AmazonS3Driver:

--- a/src/masonite/filesystem/drivers/AmazonS3Driver.py
+++ b/src/masonite/filesystem/drivers/AmazonS3Driver.py
@@ -3,6 +3,7 @@ import uuid
 
 from ..FileStream import FileStream
 from ..File import File
+from ...utils.filesystem import get_extension
 
 
 class AmazonS3Driver:
@@ -36,7 +37,7 @@ class AmazonS3Driver:
         return self.options.get("bucket")
 
     def get_name(self, path, alias):
-        extension = os.path.splitext(path)[1]
+        extension = get_extension(path)
         return f"{alias}{extension}"
 
     def put(self, file_path, content):

--- a/src/masonite/filesystem/drivers/LocalDriver.py
+++ b/src/masonite/filesystem/drivers/LocalDriver.py
@@ -5,6 +5,7 @@ from shutil import copyfile, move
 
 from ..FileStream import FileStream
 from ..File import File
+from ...utils.filesystem import get_extension
 
 
 class LocalDriver:
@@ -22,7 +23,7 @@ class LocalDriver:
         return file_path
 
     def get_name(self, path, alias):
-        extension = os.path.splitext(path)[1]
+        extension = get_extension(path)
         return f"{alias}{extension}"
 
     def put(self, file_path, content):

--- a/src/masonite/filesystem/drivers/LocalDriver.py
+++ b/src/masonite/filesystem/drivers/LocalDriver.py
@@ -1,10 +1,10 @@
 import os
+import uuid
+from os.path import isfile, join
 from shutil import copyfile, move
+
 from ..FileStream import FileStream
 from ..File import File
-import uuid
-import os
-from os.path import isfile, join
 
 
 class LocalDriver:

--- a/src/masonite/utils/filesystem.py
+++ b/src/masonite/utils/filesystem.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import pathlib
 
 
 def make_directory(directory):
@@ -70,3 +71,12 @@ def render_stub_file(stub_file, name):
 
 def get_module_dir(module_file):
     return os.path.dirname(os.path.realpath(module_file))
+
+
+def get_extension(filepath: str, without_dot=False) -> str:
+    """Get file extension from a filepath. If without_dot=True the . prefix will be removed from
+    the extension."""
+    extension = "".join(pathlib.Path(filepath).suffixes)
+    if without_dot:
+        return extension[1:]
+    return extension

--- a/tests/core/utils/test_filesystem.py
+++ b/tests/core/utils/test_filesystem.py
@@ -1,0 +1,13 @@
+from tests import TestCase
+
+from src.masonite.utils.filesystem import get_extension
+
+
+class TestFileUtils(TestCase):
+    def test_get_extension(self):
+        self.assertEqual(get_extension("log.txt"), ".txt")
+        self.assertEqual(get_extension("archive.tar.gz"), ".tar.gz")
+        self.assertEqual(get_extension("path/to/log.txt"), ".txt")
+
+        self.assertEqual(get_extension("log.txt", without_dot=True), "txt")
+        self.assertEqual(get_extension("archive.tar.gz", without_dot=True), "tar.gz")

--- a/tests/features/storage/test_local_storage.py
+++ b/tests/features/storage/test_local_storage.py
@@ -39,3 +39,10 @@ class TestLocalStorage(TestCase):
 
     def test_can_get_contents_of_directory(self):
         self.driver.get_files()
+
+    def test_get_name(self):
+        name = self.driver.get_name("some_file.txt", "log")
+        self.assertEqual(name, "log.txt")
+
+        name = self.driver.get_name("some_file.tar.gz", "archive")
+        self.assertEqual(name, "archive.tar.gz")


### PR DESCRIPTION
A new file helper has been introduced to get an extension from a path in a robust way. It handles complex extensions `.tar.gz` correctly. We can also provide `without_dot=True` to get the extension without the `.` prefix.


```python
from masonite.utils.filesystem import get_extension

get_extension("archive.tar.gz") #== .tar.gz
get_extension("test.log") #== .log

get_extension("test.log", without_dot=True) #== log
```

This PR fixes fetching extension by replacing `os.path.splitext` with this helper.
Fix #589

