### PR TITLE
Add ability to resolve simple instance as controller in routes

### DIFF
--- a/src/masonite/exceptions/exceptionite/blocks.py
+++ b/src/masonite/exceptions/exceptionite/blocks.py
@@ -1,6 +1,8 @@
 from exceptionite import Block
+
 from ... import __version__
 from ...helpers import optional
+from ...utils.str import get_controller_name
 
 
 def recursive_serializer(data):
@@ -38,14 +40,10 @@ class AppBlock(Block):
 
         # add app route data
         if route:
-            if isinstance(route.controller, str):
-                controller = route.controller
-            else:
-                controller = route.controller.__qualname__
             data.update(
                 {
                     "Route": {
-                        "Controller": controller,
+                        "Controller": get_controller_name(route.controller),
                         "Name": route.get_name(),
                         "Middlewares": route.get_middlewares(),
                     }

--- a/src/masonite/routes/HTTPRoute.py
+++ b/src/masonite/routes/HTTPRoute.py
@@ -29,6 +29,7 @@ class HTTPRoute:
         self.controllers_locations = controllers_locations
         self.controller = controller
         self.controller_class = None
+        self.controller_instance = None
         self.controller_method = None
         self._domain = None
         self._name = name

--- a/src/masonite/routes/HTTPRoute.py
+++ b/src/masonite/routes/HTTPRoute.py
@@ -160,8 +160,8 @@ class HTTPRoute:
             except LoaderNotFound as e:
                 self.e = e
                 print("\033[93mTrouble importing controller!", str(e), "\033[0m")
-        # Else it's a controller instance, we don't have to find it, just get the class
-        else:
+        # it's a class or class.method, we don't have to find it, just get the class
+        elif hasattr(controller, "__qualname__"):
             if "." in controller.__qualname__:
                 controller_name, controller_method_str = controller.__qualname__.split(
                     "."
@@ -176,6 +176,10 @@ class HTTPRoute:
             except LoaderNotFound as e:
                 self.e = e
                 print("\033[93mTrouble importing controller!", str(e), "\033[0m")
+        # it's a controller instance
+        else:
+            self.controller_instance = controller
+            controller_method_str = "__call__"
 
         # Set the controller method on class. This is a string
         self.controller_method = controller_method_str
@@ -192,14 +196,24 @@ class HTTPRoute:
             raise SyntaxError(str(self.e))
 
         if app:
-            controller = app.resolve(self.controller_class, *self.controller_bindings)
+            if self.controller_instance:
+                controller = self.controller_instance
+            else:
+                controller = app.resolve(
+                    self.controller_class, *self.controller_bindings
+                )
             # resolve route parameters
             params = self.extract_parameters(app.make("request").get_path()).values()
             # Resolve Controller Method
             response = app.resolve(getattr(controller, self.controller_method), *params)
             return response
 
-        return getattr(self.controller_class(), self.controller_method)()
+        if self.controller_instance:
+            controller = self.controller_instance
+        else:
+            controller = self.controller_class()
+
+        return getattr(controller, self.controller_method)()
 
     def middleware(self, *args):
         """Load a list of middleware to run.

--- a/src/masonite/routes/commands/RouteListCommand.py
+++ b/src/masonite/routes/commands/RouteListCommand.py
@@ -2,6 +2,8 @@
 import re
 from cleo import Command
 
+from ...utils.str import get_controller_name
+
 
 class RouteListCommand(Command):
     """
@@ -54,12 +56,7 @@ class RouteListCommand(Command):
 
     def format_route_as_row(self, route):
         """Format a Route object as a table row."""
-        # format controller name
-        if callable(route.controller):
-            # ControllerClassName.index -> ControllerClassName@index
-            controller = route.controller.__qualname__.replace(".", "@")
-        else:
-            controller = str(route.controller)
+        controller = get_controller_name(route.controller)
         row = [
             route.url,
             route.get_name() or "",

--- a/src/masonite/utils/str.py
+++ b/src/masonite/utils/str.py
@@ -2,6 +2,7 @@
 import random
 import string
 from urllib import parse
+from typing import Any
 
 
 def random_string(length=4):
@@ -74,3 +75,20 @@ def add_query_params(url: str, query_params: dict) -> str:
         base_url += "?" + parse.urlencode(all_query_params)
 
     return base_url
+
+
+def get_controller_name(controller: "str|Any") -> str:
+    """Get a controller string name from a controller argument used in routes."""
+    # controller is a class or class.method
+    if hasattr(controller, "__qualname__"):
+        if "." in controller.__qualname__:
+            controller_str = controller.__qualname__.replace(".", "@")
+        else:
+            controller_str = f"{controller.__qualname__}@__call__"
+    # controller is an instance, so the method will automatically be __call__
+    elif not isinstance(controller, str):
+        controller_str = f"{controller.__class__.__qualname__}@__call__"
+    # controller is anything else: "Controller@method"
+    else:
+        controller_str = str(controller)
+    return controller_str

--- a/tests/core/utils/test_str.py
+++ b/tests/core/utils/test_str.py
@@ -1,6 +1,13 @@
 from tests import TestCase
 
-from src.masonite.utils.str import random_string, removeprefix, removesuffix
+from src.masonite.utils.str import (
+    random_string,
+    removeprefix,
+    removesuffix,
+    get_controller_name,
+)
+
+from tests.integrations.controllers.api.TestController import TestController
 
 
 class TestStringsUtils(TestCase):
@@ -17,3 +24,14 @@ class TestStringsUtils(TestCase):
     def test_removeprefix(self):
         self.assertEqual(removeprefix("AppEvent", "App"), "Event")
         self.assertEqual(removeprefix("Event", "App"), "Event")
+
+    def test_get_controller_name(self):
+        self.assertEqual(
+            get_controller_name("WelcomeController@show"), "WelcomeController@show"
+        )
+        self.assertEqual(get_controller_name(TestController), "TestController@__call__")
+        self.assertEqual(
+            get_controller_name(TestController.show), "TestController@show"
+        )
+        controller = TestController()
+        self.assertEqual(get_controller_name(controller), "TestController@__call__")

--- a/tests/integrations/controllers/WelcomeController.py
+++ b/tests/integrations/controllers/WelcomeController.py
@@ -157,3 +157,6 @@ class WelcomeController(Controller):
 
     def server_error(self, view: View):
         raise Exception("unknown error")
+
+    def __call__(self):
+        return "welcome"

--- a/tests/routes/test_parsing_controllers.py
+++ b/tests/routes/test_parsing_controllers.py
@@ -1,0 +1,46 @@
+from unittest import TestCase
+
+from src.masonite.routes import Route
+from tests.integrations.controllers.WelcomeController import WelcomeController
+
+
+class SomeController:
+    def __call__(self):
+        return "hello"
+
+
+class TestParsingControllerInRoutes(TestCase):
+    def setUp(self):
+        Route.set_controller_locations("tests.integrations.controllers")
+        pass
+
+    def test_use_controller_string_with_method(self):
+        route = Route.get("/home", "WelcomeController@test")
+        assert route.controller_class == WelcomeController
+        assert route.controller_method == "test"
+        assert route.get_response() == "test"
+
+    def test_use_controller_string_without_method(self):
+        route = Route.get("/home", "WelcomeController")
+        assert route.controller_class == WelcomeController
+        assert route.controller_method == "__call__"
+        assert route.get_response() == "welcome"
+
+    def test_use_controller_class_with_method(self):
+        route = Route.get("/home", WelcomeController.test)
+        assert route.controller_class == WelcomeController
+        assert route.controller_method == "test"
+        assert route.get_response() == "test"
+
+    def test_use_controller_class_without_method(self):
+        route = Route.get("/home", SomeController)
+        assert route.controller_class == SomeController
+        assert route.controller_method == "__call__"
+        assert route.get_response() == "hello"
+
+    def test_use_controller_instance_without_method(self):
+        controller = SomeController()
+        route = Route.get("/home", controller)
+        assert route.controller_instance == controller
+        assert route.controller_method == "__call__"
+        assert route.get_response() == "hello"


### PR DESCRIPTION
For now we could only use "WelcomeController@show", "WelcomeController" or WelcomeController or WelcomeController.show in a route.

This PR adds the possibility to use an instance of a controller (a class):

```python
class SomeController:
    
    def __call__(self):
         return "hello"

controller = SomeController()

Route.get("/home", controller)
```

- updated `routes:list` command to handle this
- added a helper to parse the controller string name from all the possible controller options
- added unit tests to test the different behaviours
- improved controller name displayed in exceptionite context

