### PR TITLE
Added `stop` and `dump` features to TestCase

### DIFF
--- a/src/masonite/tests/HttpTestResponse.py
+++ b/src/masonite/tests/HttpTestResponse.py
@@ -6,7 +6,8 @@ from ..utils.structures import data_get
 
 
 class HttpTestResponse:
-    def __init__(self, application, request, response, route):
+    def __init__(self, testcase, application, request, response, route):
+        self.testcase = testcase
         self.application = application
         self.request = request
         self.response = response
@@ -104,6 +105,22 @@ class HttpTestResponse:
     def assertHeaderMissing(self, name):
         assert not self.response.header(name)
 
+    def dumpRequestHeaders(self):
+        """Dump request headers."""
+        self.testcase.dump(self.request.header_bag.to_dict(), "Request Headers")
+        return self
+
+    def dumpResponseHeaders(self):
+        """Dump response headers."""
+        self.testcase.dump(self.response.header_bag.to_dict(), "Response Headers")
+        return self
+
+    def ddHeaders(self):
+        """Dump request and response headers and die."""
+        self.dumpRequestHeaders()
+        self.dumpResponseHeaders()
+        self.testcase.stop()
+
     def assertLocation(self, location):
         return self.assertHasHeader("Location", location)
 
@@ -180,6 +197,16 @@ class HttpTestResponse:
             for key in keys:
                 assert not errors.get(key)
         return self
+
+    def dumpSession(self):
+        """Dump session data."""
+        self.testcase.dump(self.application.make("session").all(), "Session Data")
+        return self
+
+    def ddSession(self):
+        """Dump session data and die."""
+        self.dumpSession()
+        self.testcase.stop()
 
     def _ensure_response_has_view(self):
         """Ensure that the response has a view as its original content."""

--- a/src/masonite/tests/TestCase.py
+++ b/src/masonite/tests/TestCase.py
@@ -7,6 +7,7 @@ import unittest
 import pendulum
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
+from pprint import pprint
 
 if TYPE_CHECKING:
     from ..foundation import Application
@@ -245,14 +246,14 @@ class TestCase(unittest.TestCase):
         route = self.application.make("router").find(path, method)
         if route:
             return self.application.make("tests.response").build(
-                self.application, request, response, route
+                self, self.application, request, response, route
             )
 
         exception = RouteNotFoundException(f"No route found for url {path}")
         if self._exception_handling:
             response = self.application.make("exception_handler").handle(exception)
             return self.application.make("tests.response").build(
-                self.application, request, response, route
+                self, self.application, request, response, route
             )
         else:
             raise exception
@@ -398,3 +399,20 @@ class TestCase(unittest.TestCase):
             .where_not_null(deleted_at_column)
             .get()
         )
+
+    def dump(self, output: str, title: str = ""):
+        """Print output to console during tests. A title can be provided to be displayed at dump
+        start."""
+        with self.capsys.disabled():
+            print("\n")
+            if title:
+                print(f"\033[93m> {title}:\033[0m\n")
+            pprint(output, width=110)
+
+    def stop(self, msg: str = ""):
+        """Stop current test, a message can be given and will be displayed in the
+        console.
+        2 is the pytest exit code for user interruption.
+        https://docs.pytest.org/en/7.1.x/reference/exit-codes.html
+        """
+        return pytest.exit(msg, 2)

--- a/tests/tests/test_testcase.py
+++ b/tests/tests/test_testcase.py
@@ -97,6 +97,16 @@ class TestTestCase(TestCase):
         with self.debugMode(False):
             self.assertFalse(self.application.is_debug())
 
+    # Skipped to avoid polluting test outputs, but kept there
+    # def test_dump(self):
+    #     self.dump("test", "dump test")
+
+    # def test_dump_session(self):
+    #     self.get("/").dumpSession()
+
+    # def test_dump_headers(self):
+    #     self.get("/").dumpRequestHeaders().dumpResponseHeaders()
+
 
 class TestTestingAssertions(TestCase):
     def setUp(self):


### PR DESCRIPTION
This PR adds:

1. adds `dump()` method to a TestCase:
By default when printing something in a unit test, it's not printed in the console excepted if the test fails. To allow printing data, a `dump()` method has been added to `TestCase` (a title can be optionally provided):
```python
self.dump({"test": "key"}, "dump test")
```
![image](https://user-images.githubusercontent.com/9897999/162455989-926b5d75-a99d-43aa-a120-f2ba18230538.png)

2. adds `stop()` method to a TestCase: to make a test stop. A message can be provided
```python
self.stop("I wanted it !")
```

.3 adds helpers to HTTP test responses:
```python
self.get("/").dumpSession().dumpResponseHeaders().assertOk()
```

 - `dumpSession`: dump session data during a test
 - `dumpRequestHeaders`: dump request headers during a test
 - `dumpResponseHeaders`: dump response headers during a test
 - `ddSession`: dump session data in console during a test and die (test stops)
 - `ddHeaders`: dump request and response headers in console during a test and die (test stops)

