### PR TITLE
Add `http_method` view helper to change request method in HTML forms

### DIFF
--- a/src/masonite/providers/HelpersProvider.py
+++ b/src/masonite/providers/HelpersProvider.py
@@ -28,7 +28,7 @@ class HelpersProvider(Provider):
                 "back": lambda url=request.get_path_with_query(): (
                     Markup(f"<input type='hidden' name='__back' value='{url}' />")
                 ),
-                "http_method": lambda method: (
+                "method": lambda method: (
                     Markup(f"<input type='hidden' name='__method' value='{method}' />")
                 ),
                 "asset": urls_helper.asset,

--- a/src/masonite/providers/HelpersProvider.py
+++ b/src/masonite/providers/HelpersProvider.py
@@ -28,6 +28,9 @@ class HelpersProvider(Provider):
                 "back": lambda url=request.get_path_with_query(): (
                     Markup(f"<input type='hidden' name='__back' value='{url}' />")
                 ),
+                "http_method": lambda method: (
+                    Markup(f"<input type='hidden' name='__method' value='{method}' />")
+                ),
                 "asset": urls_helper.asset,
                 "url": urls_helper.url,
                 "mix": MixHelper(self.application).url,

--- a/src/masonite/request/request.py
+++ b/src/masonite/request/request.py
@@ -68,7 +68,7 @@ class Request(ValidatesRequest, AuthorizesRequest):
 
     def get_request_method(self) -> str:
         """Get request method (read from REQUEST_METHOD environment variable)."""
-        return self.environ.get("REQUEST_METHOD")
+        return self.input("__method") or self.environ.get("REQUEST_METHOD")
 
     def input(self, name: str, default: str = "") -> str:
         """Get a specific request input value with the given name. If the value does not exist in

--- a/src/masonite/tests/TestCase.py
+++ b/src/masonite/tests/TestCase.py
@@ -198,12 +198,19 @@ class TestCase(unittest.TestCase):
 
     def make_request(
         self,
-        data: dict = {},
+        wsgi_data: dict = {},
+        post_data: dict = {},
         path: str = "/",
         query_string: str = "application=Masonite",
         method: str = "GET",
     ) -> "Request":
-        request = Request(generate_wsgi(data, path, query_string, method))
+
+        wsgi_environ = {
+            **wsgi_data,
+            "wsgi.input": io.BytesIO(bytes(json.dumps(post_data), "utf-8")),
+            "CONTENT_LENGTH": len(str(json.dumps(post_data))),
+        }
+        request = Request(generate_wsgi(wsgi_environ, path, query_string, method))
         request.app = self.application
 
         self.application.bind("request", request)

--- a/tests/core/request/test_request.py
+++ b/tests/core/request/test_request.py
@@ -50,3 +50,11 @@ class TestRequest(TestCase):
         self.assertTrue(request.accepts_json())
         request = self.make_request({"HTTP_ACCEPT": "text/html"})
         self.assertFalse(request.accepts_json())
+
+    def test_getting_request_method(self):
+        request = self.make_request(method="POST")
+        self.assertEqual(request.get_request_method(), "POST")
+
+    def test_overriding_request_method_in_form(self):
+        request = self.make_request(post_data={"__method": "PATCH"}, method="POST")
+        self.assertEqual(request.get_request_method(), "PATCH")

--- a/tests/core/views/test_view.py
+++ b/tests/core/views/test_view.py
@@ -139,3 +139,4 @@ class TestView(TestCase):
         self.assertIn(old("username"), content)
         self.assertIn(optional(obj).value, content)
         self.assertIn("auth/base template exists", content)
+        self.assertIn("name='__method' value='PATCH'", content)

--- a/tests/integrations/templates/test_helpers.html
+++ b/tests/integrations/templates/test_helpers.html
@@ -7,4 +7,4 @@
   {{ "auth/base template exists"}}
 {% endif %}
 
-{{ http_method("PATCH") }}
+{{ method("PATCH") }}

--- a/tests/integrations/templates/test_helpers.html
+++ b/tests/integrations/templates/test_helpers.html
@@ -6,3 +6,5 @@
 {% if exists('auth/base') %}
   {{ "auth/base template exists"}}
 {% endif %}
+
+{{ http_method("PATCH") }}


### PR DESCRIPTION
This PR ports back the view helper from Masonite 3 allowing to change HTTP method from an HTML form:

```html
<form action="/", method="POST">
    {{ http_method("PATCH") }}
    <!-- ... -->
</form>
```

Fix #601