### PR TITLE
Fix order of published package migrations

### DIFF
--- a/src/masonite/packages/providers/PackageProvider.py
+++ b/src/masonite/packages/providers/PackageProvider.py
@@ -141,11 +141,13 @@ class PackageProvider(Provider):
 
     def migrations(self, *migrations):
         self.package.add_migrations(*migrations)
-        for migration in migrations:
+        # use same timestamp for all package migrations
+        timestamp = migration_timestamp()
+        for index, migration in enumerate(migrations):
             self.package.add_publishable_resource(
                 "migrations",
                 migration,
-                migrations_path(f"{migration_timestamp()}_{basename(migration)}"),
+                migrations_path(f"{timestamp}_{index + 1}_{basename(migration)}"),
             )
         return self
 

--- a/src/masonite/tests/TestCase.py
+++ b/src/masonite/tests/TestCase.py
@@ -386,11 +386,14 @@ class TestCase(unittest.TestCase):
         original = self.original_class_mocks.get(binding)
         self.application.bind(binding, original)
 
-    def fakeTime(self, pendulum_datetime: "DateTime") -> None:
+    def fakeTime(self, pendulum_datetime: "DateTime" = None) -> "DateTime":
         """Set a given pendulum instance to be returned when a "now" (or "today", "tomorrow",
         "yesterday") instance is created. It's really useful during tests to check
         timestamps logic."""
+        if pendulum_datetime is None:
+            pendulum_datetime = pendulum.now()
         pendulum.set_test_now(pendulum_datetime)
+        return pendulum_datetime
 
     def fakeTimeTomorrow(self) -> None:
         """Set the mocked time as tomorrow."""

--- a/tests/features/packages/test_publish.py
+++ b/tests/features/packages/test_publish.py
@@ -13,6 +13,7 @@ class TestPackageProviderPublishing(TestCase):
         )
 
         published_migrations = []
+        dump(migrations_path())
         for migration in os.listdir(migrations_path()):
             if migration.startswith(timestamp):
                 published_migrations.append(migration)

--- a/tests/features/packages/test_publish.py
+++ b/tests/features/packages/test_publish.py
@@ -1,0 +1,25 @@
+import os
+from tests import TestCase
+from src.masonite.utils.location import migrations_path
+
+
+class TestPackageProviderPublishing(TestCase):
+    def test_publishing_migrations(self):
+        timestamp = self.fakeTime().format("YYYY_MM_DD_HHmmss")
+        self.craft(
+            "package:publish", "test_package --r migrations"
+        ).assertOutputContains("1_create_some_table.py").assertOutputContains(
+            "2_create_other_table.py"
+        )
+
+        published_migrations = []
+        for migration in os.listdir(migrations_path()):
+            if migration.startswith(timestamp):
+                published_migrations.append(migration)
+
+        self.assertIn(f"{timestamp}_1_create_some_table.py", published_migrations)
+        self.assertIn(f"{timestamp}_2_create_other_table.py", published_migrations)
+
+        # clean up files after publishing test migrations
+        for migration in published_migrations:
+            os.remove(migrations_path(migration))

--- a/tests/features/packages/test_publish.py
+++ b/tests/features/packages/test_publish.py
@@ -1,26 +1,10 @@
-import os
 from tests import TestCase
-from src.masonite.utils.location import migrations_path
 
 
 class TestPackageProviderPublishing(TestCase):
     def test_publishing_migrations(self):
-        timestamp = self.fakeTime().format("YYYY_MM_DD_HHmmss")
         self.craft(
-            "package:publish", "test_package --r migrations"
+            "package:publish", "test_package --r migrations --dry"
         ).assertOutputContains("1_create_some_table.py").assertOutputContains(
             "2_create_other_table.py"
         )
-
-        published_migrations = []
-        dump(migrations_path())
-        for migration in os.listdir(migrations_path()):
-            if migration.startswith(timestamp):
-                published_migrations.append(migration)
-
-        self.assertIn(f"{timestamp}_1_create_some_table.py", published_migrations)
-        self.assertIn(f"{timestamp}_2_create_other_table.py", published_migrations)
-
-        # clean up files after publishing test migrations
-        for migration in published_migrations:
-            os.remove(migrations_path(migration))

--- a/tests/integrations/test_package/providers/MyTestPackageProvider.py
+++ b/tests/integrations/test_package/providers/MyTestPackageProvider.py
@@ -20,7 +20,9 @@ class MyTestPackageProvider(PackageProvider):
             .config("config/test.py", publish=True)
             .views("templates", publish=True)
             .commands(Command1(), Command2())
-            .migrations("migrations/create_some_table.py")
+            .migrations(
+                "migrations/create_some_table.py", "migrations/create_other_table.py"
+            )
             .assets("assets")
             .controllers("controllers")  # ensure this one is done before routes()
             .routes("routes/api.py", "routes/web.py")


### PR DESCRIPTION
Now the the published package migrations will contain an index, corresponding to the order of registration with the `migrations()`  helper of the PackageProvider (when publishing migrations from a package with `craft publish:package my_package`).