### PR TITLE
Add possibility to add method to controller instances

### DIFF
--- a/src/masonite/routes/HTTPRoute.py
+++ b/src/masonite/routes/HTTPRoute.py
@@ -1,3 +1,4 @@
+from inspect import isclass
 import re
 from urllib import parse
 
@@ -161,6 +162,11 @@ class HTTPRoute:
             except LoaderNotFound as e:
                 self.e = e
                 print("\033[93mTrouble importing controller!", str(e), "\033[0m")
+        # controller is an instance with a bound method
+        elif hasattr(controller, "__self__"):
+            _, controller_method_str = controller.__qualname__.split(".")
+            self.controller_instance = controller.__self__
+
         # it's a class or class.method, we don't have to find it, just get the class
         elif hasattr(controller, "__qualname__"):
             if "." in controller.__qualname__:
@@ -170,6 +176,7 @@ class HTTPRoute:
             else:
                 controller_name = controller.__qualname__
                 controller_method_str = "__call__"
+
             try:
                 self.controller_class = Loader.get_object(
                     controller.__module__, controller_name, raise_exception=True

--- a/tests/routes/test_parsing_controllers.py
+++ b/tests/routes/test_parsing_controllers.py
@@ -5,6 +5,9 @@ from tests.integrations.controllers.WelcomeController import WelcomeController
 
 
 class SomeController:
+    def method(self):
+        return "hello from method"
+
     def __call__(self):
         return "hello"
 
@@ -44,3 +47,10 @@ class TestParsingControllerInRoutes(TestCase):
         assert route.controller_instance == controller
         assert route.controller_method == "__call__"
         assert route.get_response() == "hello"
+
+    def test_use_controller_instance_with_method(self):
+        controller = SomeController()
+        route = Route.get("/home", controller.method)
+        assert route.controller_instance == controller
+        assert route.controller_method == "method"
+        assert route.get_response() == "hello from method"


### PR DESCRIPTION
In latest controller binding changes, we forgot to add the possibility to use a method for controller instances instead of the default `__call__` binding. Now we can do:

```python
class SomeController(Controller):

    def show(self):
         # ...

controller = SomeController()

Route.get("/", controller.show)
``` 