### PR TITLE
Allow unbound class resolution from container

### DIFF
--- a/src/masonite/container/container.py
+++ b/src/masonite/container/container.py
@@ -102,7 +102,10 @@ class Container:
                 if inspect.isclass(obj):
                     obj = self.resolve(obj, *arguments)
             except MissingContainerBindingNotFound:
-                # todo: comment
+                # If we don't find a bound object already in the container,
+                # we can go ahead and fall back on a simple resolve method.
+                # This allows resolving dependencies without explicit
+                # bindings.
                 self.simple(name)
                 obj = self.make(name, *arguments)
             return obj
@@ -190,10 +193,11 @@ class Container:
 
                     continue
                 if ":" in str(value):
-                    # todo: comment
                     try:
                         param = self._find_annotated_parameter(value)
                     except ContainerError:
+                        # This allows resolving dependencies without explicit bindings.
+                        # See `self.make()`.
                         param = value.annotation
                     if inspect.isclass(param):
                         param = self.resolve(param)

--- a/src/masonite/container/container.py
+++ b/src/masonite/container/container.py
@@ -106,8 +106,7 @@ class Container:
                 # we can go ahead and fall back on a simple resolve method.
                 # This allows resolving dependencies without explicit
                 # bindings.
-                self.simple(name)
-                obj = self.make(name, *arguments)
+                obj = self.resolve(name, *arguments)
             return obj
 
         raise MissingContainerBindingNotFound(

--- a/src/masonite/container/container.py
+++ b/src/masonite/container/container.py
@@ -100,11 +100,12 @@ class Container:
                 obj = self._find_obj(name)
                 self.fire_hook("make", name, obj)
                 if inspect.isclass(obj):
-                    return self.resolve(obj, *arguments)
+                    obj = self.resolve(obj, *arguments)
             except MissingContainerBindingNotFound:
                 # todo: comment
                 self.simple(name)
-                return self.make(name, *arguments)
+                obj = self.make(name, *arguments)
+            return obj
 
         raise MissingContainerBindingNotFound(
             "{0} key was not found in the container".format(name)

--- a/tests/core/foundation/test_container.py
+++ b/tests/core/foundation/test_container.py
@@ -1,0 +1,37 @@
+from tests import TestCase
+from tests.integrations.app.SayHi import SayHello
+from tests.integrations.app.GreetingService import GreetingService
+from tests.integrations.app.User import User
+
+
+class TestContainer(TestCase):
+    def test_container_can_resolve_without_binding(self):
+        # First pass - not in container
+        self.assertFalse(self.application.has(SayHello))
+        say_hello = self.application.make(SayHello)
+        self.assertIsInstance(say_hello, SayHello)
+
+        # Second pass - we still haven't bound it after the above
+        self.assertFalse(self.application.has(SayHello))
+        say_hello2 = self.application.make(SayHello)
+        self.assertIsInstance(say_hello2, SayHello)
+
+        # Container should have resolved different objects
+        self.assertIsNot(say_hello, say_hello2)
+
+    def test_container_can_resolve_nested_dependencies_without_binding(self):
+        # There's an unbound dependency in __init__()
+        service = self.application.make(GreetingService)
+
+        # There's another unbound dependency in handle()
+        # And that unbound dependency also has an unbound
+        # dependency in its __init()
+        result = self.application.resolve(getattr(service, "handle"))
+
+        self.assertIsInstance(result, User)
+        self.assertEqual("Jack Sparrow", result.name)
+
+        # All resolved but none bound
+        self.assertFalse(self.application.has(GreetingService))
+        self.assertFalse(self.application.has(SayHello))
+        self.assertFalse(self.application.has(User))

--- a/tests/integrations/app/GreetingService.py
+++ b/tests/integrations/app/GreetingService.py
@@ -1,0 +1,11 @@
+from .SayHi import SayHello
+from .Repository import Repository
+
+
+class GreetingService:
+    def __init__(self, say_hello: SayHello):
+        self.say_hello = say_hello
+
+    def handle(self, repository: Repository):
+        repository.user.name = "Jack Sparrow"
+        return repository.user

--- a/tests/integrations/app/Repository.py
+++ b/tests/integrations/app/Repository.py
@@ -1,0 +1,6 @@
+from .User import User
+
+
+class Repository:
+    def __init__(self, user: User):
+        self.user = user


### PR DESCRIPTION
This PR adds the ability to resolve class dependencies from the container that have not been previously bound.

- [x] Add tests for simple and nested cases
- [x] Add test for follow-up resolution of same class
- [x] Add comments for new behaviour
- [x] Add documentation in docs repo: https://github.com/MasoniteFramework/docs/pull/200

Closes #618 