### PR TITLE
Fixed `file`, `image` and `video` validators when validating files from request

### DIFF
--- a/src/masonite/filesystem/UploadedFile.py
+++ b/src/masonite/filesystem/UploadedFile.py
@@ -1,4 +1,5 @@
 import hashlib
+import os
 
 from ..utils.filesystem import get_extension
 
@@ -29,3 +30,7 @@ class UploadedFile:
 
     def get_content(self):
         return self.content
+
+    @property
+    def size(self):
+        return len(self.content)

--- a/src/masonite/filesystem/UploadedFile.py
+++ b/src/masonite/filesystem/UploadedFile.py
@@ -16,7 +16,7 @@ class UploadedFile:
         return self.filename
 
     def path_name(self):
-        return f"{self.name()}{self.extension()}"
+        return f"{self.name}{self.extension()}"
 
     def hash_path_name(self):
         return f"{self.hash_name()}{self.extension()}"

--- a/src/masonite/validation/Validator.py
+++ b/src/masonite/validation/Validator.py
@@ -898,16 +898,20 @@ class BaseFileValidation(BaseValidation):
         self.all_clear = True
 
     def passes(self, attribute, key, dictionary):
-        if not os.path.isfile(attribute):
+        if isinstance(attribute, str):
+            filepath = attribute
+        else:
+            filepath = attribute.name
+        if not os.path.isfile(filepath):
             self.file_check = False
             return False
         if self.size:
-            file_size = os.path.getsize(attribute)
+            file_size = os.path.getsize(filepath)
             if file_size > self.size:
                 self.size_check = False
                 self.all_clear = False
         if self.allowed_extensions:
-            mimetype, encoding = mimetypes.guess_type(attribute)
+            mimetype, encoding = mimetypes.guess_type(filepath)
             if mimetype not in self.allowed_mimetypes:
                 self.mimes_check = False
                 self.all_clear = False


### PR DESCRIPTION
Fix #619.