### PR TITLE
Add more tests for Container

### DIFF
--- a/src/masonite/container/container.py
+++ b/src/masonite/container/container.py
@@ -181,7 +181,7 @@ class Container:
                 raise ContainerError(str(e))
         else:
             for _, value in self.get_parameters(obj):
-                if value.annotation in (str, int, dict, list, tuple):
+                if type(value.annotation) in (str, int, dict, list, tuple):
                     # Ignore any times a user is simply type hinting a parameter like (parameter:str).
                     # In this case we don't want to resolve anything but we do want
                     # to insert any passing arguments we passed in
@@ -199,7 +199,11 @@ class Container:
                         # See `self.make()`.
                         param = value.annotation
                     if inspect.isclass(param):
-                        param = self.resolve(param)
+                        print(resolving_arguments)
+                        if resolving_arguments:
+                            param = self.resolve(param, *resolving_arguments)
+                        else:
+                            param = self.resolve(param)
                     objects.append(param)
                 elif "self" in str(value):
                     objects.append(obj)

--- a/src/masonite/container/container.py
+++ b/src/masonite/container/container.py
@@ -199,7 +199,6 @@ class Container:
                         # See `self.make()`.
                         param = value.annotation
                     if inspect.isclass(param):
-                        print(resolving_arguments)
                         if resolving_arguments:
                             param = self.resolve(param, *resolving_arguments)
                         else:

--- a/src/masonite/container/container.py
+++ b/src/masonite/container/container.py
@@ -292,6 +292,8 @@ class Container:
         Returns:
             object -- Returns the object found in the container.
         """
+        if isinstance(parameter.annotation, str):
+            return
         if parameter.annotation in self.swaps:
             obj = self.swaps[parameter.annotation]
             if callable(obj):
@@ -299,7 +301,6 @@ class Container:
             return obj
 
         for _, provider_class in self.objects.items():
-
             if (
                 parameter.annotation == provider_class
                 or parameter.annotation == provider_class.__class__

--- a/tests/core/foundation/test_container.py
+++ b/tests/core/foundation/test_container.py
@@ -125,9 +125,11 @@ class TestContainer(TestCase):
 
     def test_can_resolve_class_with_str_type_hinted_parameters(self):
         def my_method(test: SomeStringTypeHintedAppObject):
-            return "ok"
+            return test.app
 
         obj = self.application.resolve(my_method)
+
+        self.assertIsInstance(obj, Application)
 
     def test_can_resolve_class_with_type_hinted_parameters(self):
         def my_method(test: SomeAppObject):

--- a/tests/core/foundation/test_container.py
+++ b/tests/core/foundation/test_container.py
@@ -108,7 +108,7 @@ class TestContainer(TestCase):
         obj = self.application.resolve(my_method)
 
     def test_error_when_resolving_annotated_parameter(self):
-        from masonite.response import Response
+        from masonite.response.Response import Response
 
         def my_method(response: Response):
             return "ok"

--- a/tests/core/foundation/test_container.py
+++ b/tests/core/foundation/test_container.py
@@ -125,9 +125,20 @@ class TestContainer(TestCase):
 
     def test_can_resolve_class_with_str_type_hinted_parameters(self):
         def my_method(test: SomeStringTypeHintedAppObject):
-            return "ok"
+            return test
 
-        obj = self.application.resolve(my_method)
+        with self.assertRaises(TypeError):
+            self.application.resolve(my_method)
+
+
+    def test_can_resolve_class_with_str_type_hinted_parameters_and_pass_parameter(self):
+        def my_method(test: SomeStringTypeHintedAppObject):
+            return test
+
+        obj = self.application.resolve(my_method, 1)
+        self.assertEquals(obj.app + 1, 2)
+
+
 
     def test_can_resolve_class_with_type_hinted_parameters(self):
         def my_method(test: SomeAppObject):

--- a/tests/core/foundation/test_container.py
+++ b/tests/core/foundation/test_container.py
@@ -1,11 +1,69 @@
+from re import L
 from tests import TestCase
 from tests.integrations.app.SayHi import SayHello
 from tests.integrations.app.GreetingService import GreetingService
 from tests.integrations.app.User import User
 
+from src.masonite.exceptions import (
+    StrictContainerException,
+    MissingContainerBindingNotFound,
+)
+
+
+class SomeObject:
+
+    class_attribute = 1
+
+    def __init__(self, attribute):
+        self.attribute = attribute
+
 
 class TestContainer(TestCase):
-    def test_container_can_resolve_without_binding(self):
+    def tearDown(self):
+        super().tearDown()
+        # unbind container.test after each test
+        self.application.objects.pop("container.test", None)
+
+    def test_cannot_bind_module(self):
+        from src.masonite import foundation
+
+        with self.assertRaises(StrictContainerException):
+            self.application.bind("container.test", foundation)
+
+    def test_can_bind_object(self):
+        obj = SomeObject("test")
+        self.application.bind("container.test", obj)
+        bound_obj = self.application.make("container.test")
+
+        self.assertEqual(obj, bound_obj)
+        self.assertEqual(obj.class_attribute, 1)
+        self.assertEqual(obj.attribute, "test")
+
+        bound_obj.attribute = "test_updated"
+
+        self.assertEqual(
+            self.application.make("container.test").attribute, "test_updated"
+        )
+
+    def test_can_override_bound_objects(self):
+        obj = SomeObject("test")
+        self.application.bind("container.test", obj)
+        other_obj = SomeObject("test")
+        self.application.bind("container.test", other_obj)
+        self.assertEqual(self.application.make("container.test"), other_obj)
+
+    def test_container_has_binding(self):
+        self.assertFalse(self.application.has("SomeUnexistingBinding"))
+        self.assertFalse(self.application.has(TestContainer))
+
+        self.application.bind("container.test", 1)
+        self.assertTrue(self.application.has("container.test"))
+
+    def test_container_cannot_resolve_unbound_objects_which_are_not_classes(self):
+        with self.assertRaises(MissingContainerBindingNotFound):
+            self.application.make("container.test")
+
+    def test_container_can_resolve_classes_without_binding(self):
         # First pass - not in container
         self.assertFalse(self.application.has(SayHello))
         say_hello = self.application.make(SayHello)
@@ -19,7 +77,7 @@ class TestContainer(TestCase):
         # Container should have resolved different objects
         self.assertIsNot(say_hello, say_hello2)
 
-    def test_container_can_resolve_nested_dependencies_without_binding(self):
+    def test_container_can_resolve_nested_class_dependencies_without_binding(self):
         # There's an unbound dependency in __init__()
         service = self.application.make(GreetingService)
 
@@ -35,3 +93,24 @@ class TestContainer(TestCase):
         self.assertFalse(self.application.has(GreetingService))
         self.assertFalse(self.application.has(SayHello))
         self.assertFalse(self.application.has(User))
+
+    def test_can_collect_bindings(self):
+        bindings = self.application.collect("*.location")
+        self.assertGreater(len(bindings), 0)
+        self.assertIn("config.location", bindings.keys())
+
+    def test_can_resolve_annotated_parameter(self):
+        from src.masonite.response import Response
+
+        def my_method(response: Response):
+            return "ok"
+
+        obj = self.application.resolve(my_method)
+
+    def test_error_when_resolving_annotated_parameter(self):
+        from masonite.response import Response
+
+        def my_method(response: Response):
+            return "ok"
+
+        obj = self.application.resolve(my_method)

--- a/tests/core/foundation/test_container.py
+++ b/tests/core/foundation/test_container.py
@@ -1,4 +1,3 @@
-from re import L
 from typing import TYPE_CHECKING
 from tests import TestCase
 from tests.integrations.app.SayHi import SayHello
@@ -121,7 +120,7 @@ class TestContainer(TestCase):
         def my_method(response: Response):
             return "ok"
 
-        obj = self.application.resolve(my_method)
+        self.application.resolve(my_method)
 
     def test_can_resolve_class_with_str_type_hinted_parameters(self):
         def my_method(test: SomeStringTypeHintedAppObject):
@@ -130,7 +129,6 @@ class TestContainer(TestCase):
         with self.assertRaises(TypeError):
             self.application.resolve(my_method)
 
-
     def test_can_resolve_class_with_str_type_hinted_parameters_and_pass_parameter(self):
         def my_method(test: SomeStringTypeHintedAppObject):
             return test
@@ -138,9 +136,8 @@ class TestContainer(TestCase):
         obj = self.application.resolve(my_method, 1)
         self.assertEquals(obj.app + 1, 2)
 
-
     def test_can_resolve_class_with_type_hinted_parameters(self):
         def my_method(test: SomeAppObject):
-            return "ok"
+            return test.app
 
-        obj = self.application.resolve(my_method)
+        self.application.resolve(my_method)

--- a/tests/core/foundation/test_container.py
+++ b/tests/core/foundation/test_container.py
@@ -1,4 +1,5 @@
 from re import L
+from typing import TYPE_CHECKING
 from tests import TestCase
 from tests.integrations.app.SayHi import SayHello
 from tests.integrations.app.GreetingService import GreetingService
@@ -9,6 +10,11 @@ from src.masonite.exceptions import (
     MissingContainerBindingNotFound,
 )
 
+if TYPE_CHECKING:
+    from src.masonite.foundation import Application
+
+from src.masonite.foundation import Application
+
 
 class SomeObject:
 
@@ -16,6 +22,16 @@ class SomeObject:
 
     def __init__(self, attribute):
         self.attribute = attribute
+
+
+class SomeStringTypeHintedAppObject:
+    def __init__(self, app: "Application"):
+        self.app = app
+
+
+class SomeAppObject:
+    def __init__(self, app: Application):
+        self.app = app
 
 
 class TestContainer(TestCase):
@@ -107,10 +123,14 @@ class TestContainer(TestCase):
 
         obj = self.application.resolve(my_method)
 
-    def test_error_when_resolving_annotated_parameter(self):
-        from masonite.response.Response import Response
+    def test_can_resolve_class_with_str_type_hinted_parameters(self):
+        def my_method(test: SomeStringTypeHintedAppObject):
+            return "ok"
 
-        def my_method(response: Response):
+        obj = self.application.resolve(my_method)
+
+    def test_can_resolve_class_with_type_hinted_parameters(self):
+        def my_method(test: SomeAppObject):
             return "ok"
 
         obj = self.application.resolve(my_method)

--- a/tests/core/foundation/test_container.py
+++ b/tests/core/foundation/test_container.py
@@ -139,9 +139,6 @@ class TestContainer(TestCase):
         self.assertEquals(obj.app + 1, 2)
 
 
-
-        self.assertIsInstance(obj, Application)
-
     def test_can_resolve_class_with_type_hinted_parameters(self):
         def my_method(test: SomeAppObject):
             return "ok"

--- a/tests/integrations/config/providers.py
+++ b/tests/integrations/config/providers.py
@@ -25,7 +25,7 @@ from src.masonite.notification.providers import NotificationProvider
 from src.masonite.validation.providers.ValidationProvider import ValidationProvider
 from src.masonite.api.providers import ApiProvider
 from ..test_package import MyTestPackageProvider
-
+from debugbar.providers import DebugProvider
 from tests.integrations.providers import AppProvider
 
 PROVIDERS = [
@@ -53,4 +53,5 @@ PROVIDERS = [
     AppProvider,
     ORMProvider,
     ApiProvider,
+    DebugProvider,
 ]

--- a/tests/integrations/config/providers.py
+++ b/tests/integrations/config/providers.py
@@ -25,7 +25,7 @@ from src.masonite.notification.providers import NotificationProvider
 from src.masonite.validation.providers.ValidationProvider import ValidationProvider
 from src.masonite.api.providers import ApiProvider
 from ..test_package import MyTestPackageProvider
-from debugbar.providers import DebugProvider
+
 from tests.integrations.providers import AppProvider
 
 PROVIDERS = [
@@ -53,5 +53,4 @@ PROVIDERS = [
     AppProvider,
     ORMProvider,
     ApiProvider,
-    DebugProvider,
 ]


### PR DESCRIPTION
- Add more tests to Container
- Show the issue with the namespace. Instead of raising an error that the binding cannot be found an unhandled error is raised.

This also outlines that the Container is considering differently 
`src.masonite.response.Response` and `masonite.response.Response`.