### PR TITLE
Moved tests to their own kernel

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+black
+pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,0 @@
-black
-pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 argon2-cffi
 bcrypt>=3.2,<3.3
-black
 cleo>=0.8.1,<0.9
 cryptography>=3.3.1,<4.0
 dotty_dict>=1.3.0<1.40
@@ -14,7 +13,6 @@ masonite-orm>=2,<3
 pendulum>=2,<3
 pwnedapi
 vonage
-pytest
 python-dotenv>=0.15,<0.16
 responses
 slackblocks

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ setup(
         "hfilesize>=0.1",
         "dotty_dict>=1.3.0<1.40",
         "pyjwt>=2.3,<2.5",
-        "pytest>=7<8",
         "werkzeug>=2<3",
         "watchdog>=2<3",
     ],
@@ -188,7 +187,9 @@ setup(
     extras_require={
         "test": [
             "coverage",
-            "pytest",
+            "pytest>=7<8",
+            "black",
+            "flake8",
             "redis",
             "boto3",
             "pusher",

--- a/src/masonite/foundation/TestsKernel.py
+++ b/src/masonite/foundation/TestsKernel.py
@@ -6,6 +6,7 @@ if TYPE_CHECKING:
 from ..tests.HttpTestResponse import HttpTestResponse
 from ..tests.TestResponseCapsule import TestResponseCapsule
 
+
 class TestsKernel:
     def __init__(self, app: "Application"):
         self.application = app

--- a/src/masonite/foundation/TestsKernel.py
+++ b/src/masonite/foundation/TestsKernel.py
@@ -36,8 +36,11 @@ from ..middleware import MiddlewareCapsule
 from ..routes import Router
 from ..loader import Loader
 
+from ..tests.HttpTestResponse import HttpTestResponse
+from ..tests.TestResponseCapsule import TestResponseCapsule
 
-class Kernel:
+
+class TestsKernel:
     def __init__(self, app: "Application"):
         self.application = app
 
@@ -46,6 +49,7 @@ class Kernel:
         self.load_environment()
         self.register_framework()
         self.register_commands()
+        self.register_testing()
 
     def load_environment(self) -> None:
         """Load environment variables into the application."""
@@ -90,3 +94,7 @@ class Kernel:
                 PresetCommand(self.application),
             ),
         )
+
+    def register_testing(self) -> None:
+        test_response = TestResponseCapsule(HttpTestResponse)
+        self.application.bind("tests.response", test_response)

--- a/src/masonite/foundation/TestsKernel.py
+++ b/src/masonite/foundation/TestsKernel.py
@@ -1,99 +1,18 @@
-import os
-from cleo import Application as CommandApplication
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .Application import Application
 
-from .response_handler import response_handler
-from .. import __version__
-from ..commands import (
-    TinkerCommand,
-    CommandCapsule,
-    KeyCommand,
-    ServeCommand,
-    QueueWorkCommand,
-    QueueRetryCommand,
-    QueueTableCommand,
-    QueueFailedCommand,
-    AuthCommand,
-    MakePolicyCommand,
-    MakeControllerCommand,
-    MakeJobCommand,
-    MakeMailableCommand,
-    MakeProviderCommand,
-    PublishPackageCommand,
-    MakeTestCommand,
-    DownCommand,
-    UpCommand,
-    MakeCommandCommand,
-    MakeViewCommand,
-    MakeMiddlewareCommand,
-    PresetCommand,
-)
-from ..environment import LoadEnvironment
-from ..middleware import MiddlewareCapsule
-from ..routes import Router
-from ..loader import Loader
-
 from ..tests.HttpTestResponse import HttpTestResponse
 from ..tests.TestResponseCapsule import TestResponseCapsule
-
 
 class TestsKernel:
     def __init__(self, app: "Application"):
         self.application = app
 
     def register(self) -> None:
-        """Register core Masonite features in the project."""
-        self.load_environment()
-        self.register_framework()
-        self.register_commands()
+        """Register Tests."""
         self.register_testing()
-
-    def load_environment(self) -> None:
-        """Load environment variables into the application."""
-        LoadEnvironment()
-
-    def register_framework(self) -> None:
-        self.application.set_response_handler(response_handler)
-        self.application.use_storage_path(
-            os.path.join(self.application.base_path, "storage")
-        )
-        self.application.bind("middleware", MiddlewareCapsule())
-        self.application.bind(
-            "router",
-            Router(),
-        )
-        self.application.bind("loader", Loader())
-
-    def register_commands(self) -> None:
-        self.application.bind(
-            "commands",
-            CommandCapsule(CommandApplication("Masonite", __version__)).add(
-                TinkerCommand(),
-                KeyCommand(),
-                ServeCommand(self.application),
-                QueueWorkCommand(self.application),
-                QueueRetryCommand(self.application),
-                QueueFailedCommand(),
-                QueueTableCommand(),
-                AuthCommand(self.application),
-                MakePolicyCommand(self.application),
-                MakeControllerCommand(self.application),
-                MakeJobCommand(self.application),
-                MakeMailableCommand(self.application),
-                MakeProviderCommand(self.application),
-                PublishPackageCommand(self.application),
-                MakeTestCommand(self.application),
-                DownCommand(),
-                UpCommand(),
-                MakeCommandCommand(self.application),
-                MakeViewCommand(self.application),
-                MakeMiddlewareCommand(self.application),
-                PresetCommand(self.application),
-            ),
-        )
 
     def register_testing(self) -> None:
         test_response = TestResponseCapsule(HttpTestResponse)

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,4 +1,5 @@
 from src.masonite.foundation import Application
+from src.masonite.foundation import Kernel
 from src.masonite.foundation.TestsKernel import TestsKernel
 from src.masonite.utils.location import base_path
 from tests.integrations.config.providers import PROVIDERS
@@ -12,6 +13,7 @@ application = Application(base_path("tests/integrations"))
 """
 
 application.register_providers(
+    Kernel,
     TestsKernel,
     ApplicationKernel,
 )

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,4 +1,5 @@
-from src.masonite.foundation import Application, Kernel
+from src.masonite.foundation import Application
+from src.masonite.foundation.TestsKernel import TestsKernel
 from src.masonite.utils.location import base_path
 from tests.integrations.config.providers import PROVIDERS
 from tests.integrations.app.Kernel import Kernel as ApplicationKernel
@@ -11,7 +12,7 @@ application = Application(base_path("tests/integrations"))
 """
 
 application.register_providers(
-    Kernel,
+    TestsKernel,
     ApplicationKernel,
 )
 


### PR DESCRIPTION
This allows tests/* to be removed from production packaging without crashing the framework
Also moved dev requirements out of requirements.txt
