### PR TITLE
Fixed providing application instance to listener constructors

### DIFF
--- a/src/masonite/events/Event.py
+++ b/src/masonite/events/Event.py
@@ -1,5 +1,4 @@
 """ Event Module """
-
 import inspect
 
 
@@ -32,7 +31,7 @@ class Event:
             collected_events = self.collect_events(event)
             for collected_event in collected_events:
                 for listener in self.events.get(collected_event, []):
-                    listener().handle(event, *args, **kwargs)
+                    listener(self.application).handle(event, *args, **kwargs)
             return collected_events
         else:
             if inspect.isclass(event):
@@ -41,7 +40,7 @@ class Event:
             else:
                 lookup = event.__class__
             for listener in self.events.get(lookup, []):
-                listener().handle(event, *args, **kwargs)
+                listener(self.application).handle(event, *args, **kwargs)
 
             return [event]
 

--- a/src/masonite/stubs/events/Listener.py
+++ b/src/masonite/stubs/events/Listener.py
@@ -1,3 +1,6 @@
 class __class__:
-    def handle(self, event):
+    def __init__(self, application):
+        self.application = application
+
+    def handle(self, event, *args, **kwargs):
         pass

--- a/tests/features/event/test_event.py
+++ b/tests/features/event/test_event.py
@@ -23,21 +23,33 @@ class NewUserEvent(Event):
 
 
 class SendEmailListener:
+    def __init__(self, application):
+        self.application = application
+
     def handle(self, event):
         pass
 
 
 class UpdateAdminListener:
+    def __init__(self, application):
+        self.application = application
+
     def handle(self, event, user):
         pass
 
 
 class SendAlert:
+    def __init__(self, application):
+        self.application = application
+
     def handle(self, event):
         pass
 
 
 class AdminNotificationListener:
+    def __init__(self, application):
+        self.application = application
+
     def handle(self):
         pass
 

--- a/tests/features/event/test_event.py
+++ b/tests/features/event/test_event.py
@@ -1,7 +1,3 @@
-import time
-
-import pytest
-
 from src.masonite.events import Event
 from tests import TestCase
 
@@ -55,6 +51,9 @@ class AdminNotificationListener:
 
 
 class Subscriber:
+    def __init__(self, application):
+        self.application = application
+
     def handle(self, event):
         pass
 

--- a/tests/features/event/test_event.py
+++ b/tests/features/event/test_event.py
@@ -99,7 +99,7 @@ class TestEvent(TestCase):
         self.event.fire(NewUserEvent())
 
     def test_can_subscribe(self):
-        self.event.subscribe(Subscriber())
+        self.event.subscribe(Subscriber(self.application))
         self.assertEqual(
             self.event.fire("masonite.event_handled"), ["masonite.event_handled"]
         )


### PR DESCRIPTION
This PR fixes #651 allowing to access app instance inside a listener.

⚠️ For now this is a breaking change for users which have written listeners without the `__init__(self, application)` method...
Either we add a check to pass the application instance or not for M4 (that we would remove in M5), or we release this in M5 only.
