### PR TITLE
Register crafted Masonite classes to __init__.py

### DIFF
--- a/src/masonite/commands/MakeCommandCommand.py
+++ b/src/masonite/commands/MakeCommandCommand.py
@@ -40,6 +40,10 @@ class MakeCommandCommand(Command):
         with open(filepath, "w") as f:
             f.write(content)
 
+        # add class to __init__.py
+        with open(os.path.join(os.path.dirname(filepath), "__init__.py"), "a") as f:
+            f.write(f"from .{name} import {name}\n")
+
         self.info(f"Command Created ({relative_filename})")
 
     def get_command_path(self):

--- a/src/masonite/commands/MakeControllerCommand.py
+++ b/src/masonite/commands/MakeControllerCommand.py
@@ -62,6 +62,12 @@ class MakeControllerCommand(Command):
         with open(full_path_with_name, "w") as f:
             f.write(content)
 
+        # add class to __init__.py
+        with open(
+            os.path.join(controllers_path(folder_controller), "__init__.py"), "a"
+        ) as f:
+            f.write(f"from .{name} import {name}\n")
+
         file_created = os.path.join(parent_directory, filename)
         self.info(
             f"Controller Created ({controllers_path(file_created, absolute=False)})"

--- a/src/masonite/commands/MakeJobCommand.py
+++ b/src/masonite/commands/MakeJobCommand.py
@@ -34,6 +34,11 @@ class MakeJobCommand(Command):
             return -1
         with open(filepath, "w") as f:
             f.write(content)
+
+        # add class to __init__.py
+        with open(os.path.join(os.path.dirname(filepath), "__init__.py"), "a") as f:
+            f.write(f"from .{name} import {name}\n")
+
         self.info(f"Job Created ({jobs_path(filename, absolute=False)})")
 
     def get_template_path(self):

--- a/src/masonite/commands/MakeMailableCommand.py
+++ b/src/masonite/commands/MakeMailableCommand.py
@@ -38,6 +38,10 @@ class MakeMailableCommand(Command):
         with open(filepath, "w") as f:
             f.write(content)
 
+        # add class to __init__.py
+        with open(os.path.join(os.path.dirname(filepath), "__init__.py"), "a") as f:
+            f.write(f"from .{name} import {name}\n")
+
         self.info(f"Mailable Created ({relative_filename})")
 
     def get_mailables_path(self):

--- a/src/masonite/commands/MakeMiddlewareCommand.py
+++ b/src/masonite/commands/MakeMiddlewareCommand.py
@@ -41,6 +41,10 @@ class MakeMiddlewareCommand(Command):
         with open(filepath, "w") as f:
             f.write(content)
 
+        # add class to __init__.py
+        with open(os.path.join(os.path.dirname(filepath), "__init__.py"), "a") as f:
+            f.write(f"from .{name} import {name}\n")
+
         self.info(f"Middleware Created ({relative_filename})")
 
     def get_middleware_path(self):

--- a/src/masonite/commands/MakePolicyCommand.py
+++ b/src/masonite/commands/MakePolicyCommand.py
@@ -47,6 +47,11 @@ class MakePolicyCommand(Command):
 
         with open(file_name, "w") as f:
             f.write(content)
+
+        # add class to __init__.py
+        with open(os.path.join(os.path.dirname(file_name), "__init__.py"), "a") as f:
+            f.write(f"from .{name} import {name}\n")
+
         self.info(f"Policy Created ({file_name})")
 
     def get_template_path(self):

--- a/src/masonite/commands/MakeProviderCommand.py
+++ b/src/masonite/commands/MakeProviderCommand.py
@@ -39,6 +39,11 @@ class MakeProviderCommand(Command):
 
         with open(filepath, "w") as f:
             f.write(content)
+
+        # add class to __init__.py
+        with open(os.path.join(os.path.dirname(filepath), "__init__.py"), "a") as f:
+            f.write(f"from .{name} import {name}\n")
+
         self.info(f"Provider Created ({relative_filename})")
 
     def get_providers_path(self):


### PR DESCRIPTION
As a lot of people are confused with Python import system: they are using wrong imports after crafting a Mailable or a Middleware.
A lot of people are doing
```python
from app.mailables import Test #== Test is the mailable module
```
instead of
```python
from app.mailables.Test import Test #== Test is the mailable class
```
...or for the first line to work, the user should put a ` __init__.py` file in `app/mailables/` containing the following import `from .Test import Test`. 👉 the PR is automating this process when doing `python craft mailable Test`.

It has been done for each command which are creating a class in a configured location.
