### PR TITLE
numeric validation rule to accepts floats

### DIFF
--- a/src/masonite/validation/Validator.py
+++ b/src/masonite/validation/Validator.py
@@ -484,10 +484,10 @@ class numeric(BaseValidation):
     def passes(self, attribute, key, dictionary):
         if isinstance(attribute, list):
             for value in attribute:
-                if not str(value).isdigit():
+                if not str(value).replace(".", "", 1).isdigit():
                     return False
         else:
-            return str(attribute).isdigit()
+            return str(attribute).replace(".", "", 1).isdigit()
 
         return True
 

--- a/tests/features/validation/test_validation.py
+++ b/tests/features/validation/test_validation.py
@@ -445,7 +445,15 @@ class TestValidation(unittest.TestCase):
 
         self.assertEqual(len(validate), 0)
 
+        validate = Validator().validate({"test": 1.9}, numeric(["test"]))
+
+        self.assertEqual(len(validate), 0)
+
         validate = Validator().validate({"test": "hey"}, numeric(["test"]))
+
+        self.assertEqual(validate.all(), {"test": ["The test must be a numeric."]})
+
+        validate = Validator().validate({"test": '1..9'}, numeric(["test"]))
 
         self.assertEqual(validate.all(), {"test": ["The test must be a numeric."]})
 


### PR DESCRIPTION
Hi

this confuesed me a bit , I saw php accepts floats with `is_numeric`method same thing with Laravel numeric rule but in python `isdigits` for some reason doesn't accept floats, so I found a solution and made this PR.