### PR TITLE
docs: Fix a few typos

### DIFF
--- a/WHITEPAPER.md
+++ b/WHITEPAPER.md
@@ -275,7 +275,7 @@ Notice that theres nothing in the class above that isn't related to sending an e
 
 ### Component Classes
 
-Component classes are another part of this relationship. A component is also a class that does 1 thing and 1 thing only. This class should have a small peice of logic **that is designed to clean up other parts of the code later down the line**. For example, if we want to compile an email from `joe@masoniteproject.com, idmann509@gmail.com` to `<joe@masoniteproject.com>, <idmann509@gmail.com>` we could loop through the emails and append them inside the SMTP driver, right?
+Component classes are another part of this relationship. A component is also a class that does 1 thing and 1 thing only. This class should have a small piece of logic **that is designed to clean up other parts of the code later down the line**. For example, if we want to compile an email from `joe@masoniteproject.com, idmann509@gmail.com` to `<joe@masoniteproject.com>, <idmann509@gmail.com>` we could loop through the emails and append them inside the SMTP driver, right?
 
 This would look kind of messy and with some psuedo code would look like this:
 
@@ -315,7 +315,7 @@ cc_emails = Recipient(cc_emails).header()
 
 The same rules apply to an email attachment.
 
-So these component classes should be used where applicable so we can add features at a central location and it be propogated throughout other drivers. They should also do 1 thing and 1 thing only to not break anything with side effects
+So these component classes should be used where applicable so we can add features at a central location and it be propagated throughout other drivers. They should also do 1 thing and 1 thing only to not break anything with side effects
 
 ### Registering Drivers
 

--- a/src/masonite/foundation/Application.py
+++ b/src/masonite/foundation/Application.py
@@ -86,7 +86,7 @@ class Application(Container):
 
     def is_running_in_console(self) -> bool:
         """Check if application is running in console. This is useful to only run some providers
-        logic when used in console. We can differenciate if the application is being served or
+        logic when used in console. We can differentiate if the application is being served or
         if an application command is ran in console."""
         if len(sys.argv) > 1:
             return sys.argv[1] != "serve"

--- a/src/masonite/providers/FrameworkProvider.py
+++ b/src/masonite/providers/FrameworkProvider.py
@@ -23,7 +23,7 @@ class FrameworkProvider(Provider):
         self.application.bind("presets", presets)
 
         # @M5 remove this and add SecurityProvider in default project
-        # @M5 old projects won't have securiy options so put default here. remove this for M5.
+        # @M5 old projects won't have security options so put default here. remove this for M5.
         options = config("security.cors")
         if not options:
             options = {

--- a/src/masonite/response/response.py
+++ b/src/masonite/response/response.py
@@ -38,7 +38,7 @@ class Response:
         return self.data()
 
     def make_headers(self, content_type: str = "text/html; charset=utf-8") -> None:
-        """Recompute Content-Length of the response after modyifing it."""
+        """Recompute Content-Length of the response after modifying it."""
         self.header_bag.add(Header("Content-Length", str(len(self.to_bytes()))))
 
         # If the user did not change it directly

--- a/src/masonite/utils/structures.py
+++ b/src/masonite/utils/structures.py
@@ -72,7 +72,7 @@ def data_get(dictionary, key, default=None):
 
 
 def data_set(dictionary, key, value, overwrite=True):
-    """Set dictionary value at key using nested notation. Values are overriden by default but
+    """Set dictionary value at key using nested notation. Values are overridden by default but
     this behaviour can be changed by passing overwrite=False.
     The dictionary is edited in place but is also returned.
 

--- a/src/masonite/views/view.py
+++ b/src/masonite/views/view.py
@@ -104,7 +104,7 @@ class View:
         if self.template in self.composers:
             self.dictionary.update(self.composers.get(self.template))
 
-        # Check if there is just an astericks in the composer
+        # Check if there is just an asterisks in the composer
         if "*" in self.composers:
             self.dictionary.update(self.composers.get("*"))
 


### PR DESCRIPTION
There are small typos in:
- WHITEPAPER.md
- src/masonite/foundation/Application.py
- src/masonite/providers/FrameworkProvider.py
- src/masonite/response/response.py
- src/masonite/utils/structures.py
- src/masonite/views/view.py

Fixes:
- Should read `security` rather than `securiy`.
- Should read `propagated` rather than `propogated`.
- Should read `piece` rather than `peice`.
- Should read `modifying` rather than `modyifing`.
- Should read `overridden` rather than `overriden`.
- Should read `differentiate` rather than `differenciate`.
- Should read `asterisks` rather than `astericks`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md