### PR TITLE
Fixed loading cookies on Linux environments

### DIFF
--- a/src/masonite/cookies/CookieJar.py
+++ b/src/masonite/cookies/CookieJar.py
@@ -59,9 +59,10 @@ class CookieJar:
         return dic
 
     def load(self, cookie_string):
-        for compound_value in cookie_string.split("; "):
+        for compound_value in cookie_string.split(";"):
             if "=" in compound_value:
                 key, value = compound_value.split("=", 1)
+                key, value = key.strip(), value.strip()
                 self.load_cookie(key, value)
         return self
 


### PR DESCRIPTION
Hello,

I came across this issue which I could not explain, but my best guess is it's got something to do with the Linux,
where the `self.environ.get("HTTP_COOKIE", "")` returns the cookie_string which is delimited with ";" whereas on my local Mac environment it returns the cookie_string which is delimited with "; " which creates an issue where the API calls fail as the CSRF tokens doesn't match.

The solution provided in the PR is a better way to handle cookies it's inspired by how Django & Laravel handles cookies and should work for both scenarios. 