### PR TITLE
Fix incorrect extension being returned

### DIFF
--- a/src/masonite/utils/filesystem.py
+++ b/src/masonite/utils/filesystem.py
@@ -87,4 +87,3 @@ def get_extension(filepath: str, without_dot=False) -> str:
     if without_dot:
         return extension[1:]
     return extension
-

--- a/src/masonite/utils/filesystem.py
+++ b/src/masonite/utils/filesystem.py
@@ -76,7 +76,7 @@ def get_module_dir(module_file):
 def get_extension(filepath: str, without_dot=False) -> str:
     """Get file extension from a filepath. If without_dot=True the . prefix will be removed from
     the extension."""
-    extension = "".join(pathlib.Path(filepath).suffixes)
+    extension = os.path.splitext(filepath)[1]
     if without_dot:
         return extension[1:]
     return extension

--- a/src/masonite/utils/filesystem.py
+++ b/src/masonite/utils/filesystem.py
@@ -1,7 +1,8 @@
 import os
 import platform
 import pathlib
-
+import mimetypes
+from masonite.environment import env
 
 def make_directory(directory):
     """Create a directory at the given path for a file if it does not exist"""

--- a/src/masonite/utils/filesystem.py
+++ b/src/masonite/utils/filesystem.py
@@ -73,10 +73,17 @@ def get_module_dir(module_file):
     return os.path.dirname(os.path.realpath(module_file))
 
 
+def splitext(path):
+    for ext in env('PRESERVE_EXTENSIONS', '').split(','):
+        if path.endswith(ext):
+            return path[:-len(ext)], path[-len(ext):]
+    return os.path.splitext(path)
+
 def get_extension(filepath: str, without_dot=False) -> str:
     """Get file extension from a filepath. If without_dot=True the . prefix will be removed from
     the extension."""
-    extension = os.path.splitext(filepath)[1]
+    extension = splitext(filepath)[1]
     if without_dot:
         return extension[1:]
     return extension
+


### PR DESCRIPTION
When a filename has multiple dots it returns everything after first dot.  os.path.splitext() correctly handles dot names and even '.hidden_linux_file'