### PR TITLE
RedisDriver empty internal cache

### DIFF
--- a/src/masonite/cache/drivers/RedisDriver.py
+++ b/src/masonite/cache/drivers/RedisDriver.py
@@ -13,6 +13,7 @@ class RedisDriver:
 
     def set_options(self, options: dict) -> "RedisDriver":
         self.options = options
+        self.get_connection()
         return self
 
     def get_connection(self) -> "Redis":


### PR DESCRIPTION
when calling `Cache.get()` will throw Nonetype error .. issue is `get_connection()` not being called anywhere 