### PR TITLE
Compact helper - Allow scalar types to be assigned regardless of content

### DIFF
--- a/src/masonite/helpers/compact.py
+++ b/src/masonite/helpers/compact.py
@@ -15,7 +15,7 @@ class Compact:
             found = []
             for key, value in frame.f_back.f_locals.items():
                 if value == arg:
-                    if isinstance(value, str):
+                    if isinstance(value, (str, int, float, bytes, bool)):
                         cls.dictionary.update({key: value})
                         continue
 

--- a/src/masonite/helpers/compact.py
+++ b/src/masonite/helpers/compact.py
@@ -15,6 +15,10 @@ class Compact:
             found = []
             for key, value in frame.f_back.f_locals.items():
                 if value == arg:
+                    if isinstance(value, str):
+                        cls.dictionary.update({key: value})
+                        continue
+
                     for f in found:
                         if value is f and f is not None:
                             raise AmbiguousError(

--- a/src/masonite/helpers/compact.py
+++ b/src/masonite/helpers/compact.py
@@ -8,14 +8,10 @@ class Compact:
 
         cls.dictionary = {}
         for arg in args:
-            if isinstance(arg, dict):
-                cls.dictionary.update(arg)
-                continue
-
             found = []
             for key, value in frame.f_back.f_locals.items():
                 if value == arg:
-                    if isinstance(value, (str, int, float, bytes, bool)):
+                    if isinstance(value, (dict, str, int, float, bytes, bool)):
                         cls.dictionary.update({key: value})
                         continue
 

--- a/src/masonite/helpers/compact.py
+++ b/src/masonite/helpers/compact.py
@@ -26,4 +26,5 @@ class Compact:
 
         if len(args) != len(cls.dictionary):
             raise ValueError("Could not find all variables in this")
+
         return cls.dictionary


### PR DESCRIPTION
This PR fixes the issue where strings that contain the same content could not be assigned to multiple variables when using `compact()`.

example: 
This will throw the error "`Cannot contain variables with multiple of the same object in scope`"
Due to `data2` and `data3` having the exact same string content

```python
        data1 = {"item1": 10}
        data2 = json.dumps([])
        data3 = json.dumps([])

        return self.view.render(
            "path.to.index",
            compact(data1, data2, data3),
        )
 ```

This PR also fixes the issue when passing a dict that the keys of the dict will be added as individual items  and not the actual dict as expected. 
