### PR TITLE
Feature: add Amazon Services Provider

### DIFF
--- a/src/masonite/services/AmazonServices.py
+++ b/src/masonite/services/AmazonServices.py
@@ -1,0 +1,113 @@
+import warnings
+from typing import Any
+from botocore.client import BaseClient
+from ..exceptions import InvalidConfigurationSetup
+
+
+class AmazonServices:
+    """Wrapper for AWS services"""
+
+    def __init__(self, application, config=None):
+        self.application = application
+        self.config = config or {}
+        self._resources = {}
+        self._clients = {}
+
+    def services(self):
+        """list configured service names"""
+        return self.config.keys()
+
+    def client(self, name=None) -> "BaseClient|None":
+        """get a named client interface"""
+        if not name:
+            return None
+
+        try:
+            return self._clients[name]
+        except KeyError:
+            # client not yet initialised
+            client = self._setup_client(name)
+            self._clients[name] = client = client
+            return client
+
+    def resource(self, name=None) -> "Any|None":
+        """get a named resource interface"""
+        if not name:
+            return None
+
+        try:
+            warnings.warn(
+                """The 'resource' interface is no longer being updated by Amazon in boto3.\n 
+                It is recommended to use the 'client' interface instead""",
+                DeprecationWarning,
+            )
+            return self._resources[name]
+        except KeyError:
+            # resource not yet initialised
+            resource = self._setup_resource(name)
+            self._resources[name] = resource
+            return resource
+
+    def _setup_client(self, name: str = None) -> BaseClient:
+        """setup the service using the 'client' API"""
+        try:
+            import boto3
+            from botocore.exceptions import UnknownServiceError
+
+            try:
+                svc_config = self.service_config(name, True)
+
+                service_name = svc_config.get("service", name)
+                extra_config = svc_config.get("options", {})
+
+                return boto3.client(service_name, **extra_config)
+            except UnknownServiceError as error:
+                raise InvalidConfigurationSetup(
+                    f"Unknown client interface '{service_name}': {error}"
+                )
+        except ImportError:
+            raise ModuleNotFoundError(
+                "Could not find the 'boto3' library. Run 'pip install boto3' to fix this."
+            )
+
+    def service_config(self, name: str, full: bool = False) -> dict:
+        """get the service config"""
+        try:
+            svc_config: dict = self.config[name]
+            # services are active by default
+            if not svc_config.get("active", True):
+                raise InvalidConfigurationSetup(f"Resource '{name} is not active")
+
+            if not full:
+                # remove internal configuration keys (if any)
+                svc_config.pop("service", None)
+                svc_config.pop("options", None)
+                svc_config.pop("active", None)
+
+            return svc_config
+        except KeyError:
+            raise InvalidConfigurationSetup(
+                f"No Amazon Service configuration found for: {name}"
+            )
+
+    def _setup_resource(self, name: str = None) -> Any:
+        """setup the service using the 'resource' interface"""
+        try:
+            import boto3
+            from botocore.exceptions import UnknownServiceError
+
+            try:
+                svc_config = self.service_config(name, True)
+
+                service_name = svc_config.get("service", name)
+                extra_config = svc_config.get("options", {})
+
+                return boto3.resource(service_name, **extra_config)
+            except UnknownServiceError as error:
+                raise InvalidConfigurationSetup(
+                    f"Unknown resource interface '{service_name}': {error}"
+                )
+        except ImportError:
+            raise ModuleNotFoundError(
+                "Could not find the 'boto3' or 'botocore' module. Run 'pip install boto3' to fix this."
+            )

--- a/src/masonite/services/AmazonServices.py
+++ b/src/masonite/services/AmazonServices.py
@@ -1,6 +1,8 @@
 import warnings
 from typing import Any
+
 from botocore.client import BaseClient
+
 from ..exceptions import InvalidConfigurationSetup
 
 
@@ -37,8 +39,8 @@ class AmazonServices:
 
         try:
             warnings.warn(
-                """The 'resource' interface is no longer being updated by Amazon in boto3.\n 
-                It is recommended to use the 'client' interface instead""",
+                "The 'resource' interface is no longer being updated by Amazon in boto3.\n \
+                It is recommended to use the 'client' interface instead",
                 DeprecationWarning,
             )
             return self._resources[name]

--- a/src/masonite/services/__init__.py
+++ b/src/masonite/services/__init__.py
@@ -1,0 +1,1 @@
+from .AmazonServices import AmazonServices

--- a/src/masonite/services/providers/AmazonServicesProvider.py
+++ b/src/masonite/services/providers/AmazonServicesProvider.py
@@ -1,6 +1,6 @@
-from ..AmazonServices import AmazonServices
 from ...configuration import config
 from ...providers import Provider
+from ..AmazonServices import AmazonServices
 
 
 class AmazonServicesProvider(Provider):

--- a/src/masonite/services/providers/AmazonServicesProvider.py
+++ b/src/masonite/services/providers/AmazonServicesProvider.py
@@ -1,0 +1,16 @@
+from ..AmazonServices import AmazonServices
+from ...configuration import config
+from ...providers import Provider
+
+
+class AmazonServicesProvider(Provider):
+    wsgi = False
+
+    def register(self):
+        services_config = config("amazon.services")
+
+        services = AmazonServices(self.application, services_config)
+        self.application.bind("amazon", services)
+
+    def boot(self):
+        pass

--- a/src/masonite/services/providers/AmazonServicesProvider.py
+++ b/src/masonite/services/providers/AmazonServicesProvider.py
@@ -7,9 +7,10 @@ class AmazonServicesProvider(Provider):
     wsgi = False
 
     def register(self):
-        services_config = config("amazon.services")
+        services = config("amazon.services", {})
+        common = config("amazon.common_config", {})
 
-        services = AmazonServices(self.application, services_config)
+        services = AmazonServices(self.application, services, common)
         self.application.bind("amazon", services)
 
     def boot(self):

--- a/src/masonite/services/providers/__init__.py
+++ b/src/masonite/services/providers/__init__.py
@@ -1,0 +1,1 @@
+from .AmazonServicesProvider import AmazonServicesProvider

--- a/tests/features/services/test_amazon_services.py
+++ b/tests/features/services/test_amazon_services.py
@@ -1,7 +1,8 @@
+import pytest
 from boto3.exceptions import ResourceNotExistsError
+
 from src.masonite.exceptions import InvalidConfigurationSetup
 from tests import TestCase
-import pytest
 
 
 class TestAmazonServices(TestCase):

--- a/tests/features/services/test_amazon_services.py
+++ b/tests/features/services/test_amazon_services.py
@@ -1,0 +1,61 @@
+from boto3.exceptions import ResourceNotExistsError
+from src.masonite.exceptions import InvalidConfigurationSetup
+from tests import TestCase
+import pytest
+
+
+class TestAmazonServices(TestCase):
+    def test_clients(self):
+        amazon = self.application.make("amazon")
+        # valid clients
+        s3_client = amazon.client("s3")
+        assert s3_client is not None
+        # with a "service" key
+        gateway1 = amazon.client("api_gateway")
+        assert gateway1 is not None
+
+        # invalid options
+        with pytest.raises(InvalidConfigurationSetup) as e_info:
+            amazon.client("some_gateway")
+        assert (
+            str(e_info.value)
+            .lower()
+            .startswith("no amazon service configuration found")
+        )
+        with pytest.raises(InvalidConfigurationSetup) as e_info:
+            amazon.client("disabled")
+        assert str(e_info.value).lower().endswith("is not active")
+
+    def test_resources(self):
+        amazon = self.application.make("amazon")
+        # valid resources
+        s3_resource = amazon.resource("s3")
+        assert s3_resource is not None
+
+        # invalid resource interface with "service" key
+        with pytest.raises(ResourceNotExistsError) as e_info:
+            gateway1 = amazon.resource("api_gateway")
+        assert "resource does not exist" in str(e_info.value).lower()
+
+        # invalid options
+        with pytest.raises(InvalidConfigurationSetup) as e_info:
+            amazon.resource("some_gateway")
+        assert (
+            str(e_info.value)
+            .lower()
+            .startswith("no amazon service configuration found")
+        )
+        with pytest.raises(InvalidConfigurationSetup) as e_info:
+            amazon.resource("disabled")
+        assert str(e_info.value).lower().endswith("is not active")
+
+    def test_service_config(self):
+        amazon = self.application.make("amazon")
+
+        full_config = amazon.service_config("s3", True)
+        assert all(k in full_config for k in ("options", "buckets"))
+
+        limited_config = amazon.service_config("s3")
+        assert limited_config.get("options", False) == False
+        assert len(limited_config) == 1
+        assert len(limited_config.get("buckets")) == 2

--- a/tests/integrations/config/amazon.py
+++ b/tests/integrations/config/amazon.py
@@ -8,19 +8,11 @@ SERVICES = {
         },
         "options": {
             "endpoint_url": "http://localhost:4566",
-            "aws_access_key_id": os.getenv("AWS_CLIENT"),
-            "aws_secret_access_key": os.getenv("AWS_SECRET"),
-            "region_name": 'us-eat-1',
         },
     },
     # using a more readable alias for the service
     "api_gateway": {
         "service": "apigateway",
-        "options": {
-            "aws_access_key_id": os.getenv("AWS_CLIENT"),
-            "aws_secret_access_key": os.getenv("AWS_SECRET"),
-            "region_name": 'us-eat-1',
-        },
     },
     "disabled": {
         "active": False,
@@ -29,10 +21,11 @@ SERVICES = {
     "invalid": {
         "active": True,
         "service": "dummy",
-        "options": {
-            "aws_access_key_id": os.getenv("AWS_CLIENT"),
-            "aws_secret_access_key": os.getenv("AWS_SECRET"),
-            "region_name": 'us-eat-1',
-        },
     },
+}
+
+COMMON_CONFIG = {
+    "aws_access_key_id": os.getenv("AWS_CLIENT"),
+    "aws_secret_access_key": os.getenv("AWS_SECRET"),
+    "region_name": 'us-eat-1',
 }

--- a/tests/integrations/config/amazon.py
+++ b/tests/integrations/config/amazon.py
@@ -1,3 +1,10 @@
+import os
+
+# defined for testing purposes only
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+os.environ.setdefault("AWS_ACCESS_KEY_ID", os.getenv("AWS_CLIENT"))
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", os.getenv("AWS_SECRET"))
+
 SERVICES = {
     "s3": {
         "buckets": {

--- a/tests/integrations/config/amazon.py
+++ b/tests/integrations/config/amazon.py
@@ -10,6 +10,7 @@ SERVICES = {
             "endpoint_url": "http://localhost:4566",
             "aws_access_key_id": os.getenv("AWS_CLIENT"),
             "aws_secret_access_key": os.getenv("AWS_SECRET"),
+            "region_name": 'us-eat-1',
         },
     },
     # using a more readable alias for the service
@@ -18,6 +19,7 @@ SERVICES = {
         "options": {
             "aws_access_key_id": os.getenv("AWS_CLIENT"),
             "aws_secret_access_key": os.getenv("AWS_SECRET"),
+            "region_name": 'us-eat-1',
         },
     },
     "disabled": {
@@ -30,7 +32,7 @@ SERVICES = {
         "options": {
             "aws_access_key_id": os.getenv("AWS_CLIENT"),
             "aws_secret_access_key": os.getenv("AWS_SECRET"),
+            "region_name": 'us-eat-1',
         },
-
     },
 }

--- a/tests/integrations/config/amazon.py
+++ b/tests/integrations/config/amazon.py
@@ -1,0 +1,23 @@
+SERVICES = {
+    "s3": {
+        "buckets": {
+            "images": "the-images",
+            "console": "console-attachments",
+        },
+        "options": {
+            "endpoint_url": "http://localhost:4566",
+        },
+    },
+    # using a more readable alias for the service
+    "api_gateway": {
+        "service": "apigateway",
+    },
+    "disabled": {
+        "active": False,
+        "service": "s3",
+    },
+    "invalid": {
+        "active": True,
+        "service": "dummy",
+    },
+}

--- a/tests/integrations/config/amazon.py
+++ b/tests/integrations/config/amazon.py
@@ -1,10 +1,5 @@
 import os
 
-# defined for testing purposes only
-os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
-os.environ.setdefault("AWS_ACCESS_KEY_ID", os.getenv("AWS_CLIENT"))
-os.environ.setdefault("AWS_SECRET_ACCESS_KEY", os.getenv("AWS_SECRET"))
-
 SERVICES = {
     "s3": {
         "buckets": {
@@ -13,11 +8,17 @@ SERVICES = {
         },
         "options": {
             "endpoint_url": "http://localhost:4566",
+            "aws_access_key_id": os.getenv("AWS_CLIENT"),
+            "aws_secret_access_key": os.getenv("AWS_SECRET"),
         },
     },
     # using a more readable alias for the service
     "api_gateway": {
         "service": "apigateway",
+        "options": {
+            "aws_access_key_id": os.getenv("AWS_CLIENT"),
+            "aws_secret_access_key": os.getenv("AWS_SECRET"),
+        },
     },
     "disabled": {
         "active": False,
@@ -26,5 +27,10 @@ SERVICES = {
     "invalid": {
         "active": True,
         "service": "dummy",
+        "options": {
+            "aws_access_key_id": os.getenv("AWS_CLIENT"),
+            "aws_secret_access_key": os.getenv("AWS_SECRET"),
+        },
+
     },
 }

--- a/tests/integrations/config/providers.py
+++ b/tests/integrations/config/providers.py
@@ -23,6 +23,7 @@ from src.masonite.providers import (
 from src.masonite.scheduling.providers import ScheduleProvider
 from src.masonite.notification.providers import NotificationProvider
 from src.masonite.validation.providers.ValidationProvider import ValidationProvider
+from src.masonite.services.providers import AmazonServicesProvider
 from src.masonite.api.providers import ApiProvider
 from ..test_package import MyTestPackageProvider
 
@@ -49,6 +50,7 @@ PROVIDERS = [
     AuthenticationProvider,
     AuthorizationProvider,
     ValidationProvider,
+    AmazonServicesProvider,
     MyTestPackageProvider,
     AppProvider,
     ORMProvider,


### PR DESCRIPTION
This Provider provides a nice uniform way of accessing the low level 'client' or 'resource' interfaces provided by boto3 to AWS services.
In addition it provides a way to consolidate (service and app) configuration  for each service to use in your app.

Use it like this

- Add the `AmazonServicesProvider` to your `providers.py`
- Add a services config `amazon.py` containing services you want to use in your app
- Use the AmazonService class in your app

NOTE: the resources interface is still available but no longer being updated with new services.  
It is recommended by Amazon to use the client interface for access to all services.
A Deprecation warning will be raised if the 'resource' interface is accessed.  

```python
#config/amazon.py
SERVICES = {
    "s3": {
        # all keys except "service", "active" and "options" are useful for app specific configuration
        "buckets": {
            "images": "the-images",
            "console": "console-attachments",
        },
        "active": True, # Optional: defaults to True if not provided
        # any keys in the 'options' will be passed directly to the client or resource interface
        "options": { 
            "endpoint_url": "http://localhost:4566", # This is useful for development with LocalStack
        },
    },
    # using a more readable alias for the service
    "api_gateway": {
        "service": "apigateway", # this is the service name that boto3 uses
    },
}

# OPTIONAL: configuration that is common to all services
# NOTE: this can be overridden in the service `options` block if necessary 
COMMON_CONFIG = {
    "aws_access_key_id": "<access key ID>",
    "aws_secret_access_key": "<secret key>",
    "region_name": 'us-eat-1',
}

```
In your Controller 
```python
# app/controllers/SomeController.py

from masonite.services import AmazonServices
...
class SomeController(Controller):
    def submit(self, amazon: AmazonServices):
        file: UploadedFile = self.request.input("file_registrations")
        s3 = amazon.resource("s3")

        bucket_name = amazon.service_config("s3")["buckets"]["console"]
        exists_path = "/some/bucket/path/to/object"
        s3_obj = s3.Object(bucket_name, exists_path)

        # check if the object exists
        # if so delete it so it can be replaced
        try:
            s3_obj.load()
            s3_obj.delete()
        except ClientError as e:
            if e.response["Error"]["Code"] == "404":
                # The object does not exist.
                pass
            else:
                # Something else has gone wrong.
                raise e

        # put the file in s3         
        try:
            s3_obj.put(Body=file.content)
        except ClientError as e:
            raise e

```
or alternativley esewhere in your app
```python
amazon = self.application.make("amazon")
s3 = amazon.client("s3")
```

I am Interested in any feedback or thoughts on this provider.

Also once this (hopefully) is merged I will update the docs and cookie-cutter to include this