### PR TITLE
fix: add missing dependency 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ werkzeug>=2<3
 watchdog>=2<3
 whitenoise>=5.2,<5.3
 pyjwt>=2.3,<2.5
+attrs>=23

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         "pytest>=7<8",
         "werkzeug>=2<3",
         "watchdog>=2<3",
+        "attrs>=23"
     ],
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[


### PR DESCRIPTION
New installations fails because `attrs` is not added to setup.py. 

Reference: #752 