### PR TITLE
Autoload validation classes from Validator

### DIFF
--- a/src/masonite/validation/Validator.py
+++ b/src/masonite/validation/Validator.py
@@ -1411,6 +1411,12 @@ class Validator:
             self.__dict__.update({obj.__name__: obj})
             ValidationFactory().register(obj)
 
+    def __getattr__(self, name):
+        if name in ValidationFactory().registry:
+            return ValidationFactory().registry[name]
+
+        raise AttributeError("Validator has no attribute {}".format(name))
+
 
 class ValidationFactory:
 

--- a/tests/features/validation/test_request_validation.py
+++ b/tests/features/validation/test_request_validation.py
@@ -1,5 +1,5 @@
 from tests import TestCase
-
+from src.masonite.validation import Validator
 
 class TestValidation(TestCase):
     def test_can_validate_request(self):
@@ -21,3 +21,16 @@ class TestValidation(TestCase):
         )
 
         self.assertEqual(validation.all(), {"email": ["The email field is required."]})
+
+    def test_can_forward_validation_calls(self):
+        request = self.make_request(query_string="")
+        validate = Validator()
+
+        errors = request.validate(
+            validate.required(['user', 'email']),
+            validate.accepted('terms')
+        )
+
+        self.assertIn("The user field is required.", errors.get("user"))
+        self.assertIn("The email field is required.", errors.get("email"))
+        self.assertIn("The terms must be accepted.", errors.get("terms"))


### PR DESCRIPTION
[In docs](https://docs.masoniteproject.com/features/validation#numeric), you could see something like this:

```python
from masonite.validation import Validator
from masonite.validation import required, accepted
from masonite.request import Request
from masonite.response import Response

def show(self, request: Request, response: Response, validate: Validator):
    """
    Incoming Input: {
        'user': 'username123',
        'email': 'user@example.com',
        'terms': 'on'
    }
    """
    errors = request.validate(
        validate.required(['user', 'email']),
        validate.accepted('terms')
    )

    if errors:
        return response.back().with_errors(errors)
```

Specifically, this two lines will raise an error, because required and accepted are not attributes of Validator class. Instead, you should import the class from `masonite.validation`, but, in order to make it work more naturally, I propose this fix to make it work.

```python
validate.required(['user', 'email']),
validate.accepted('terms')
```