### PR TITLE
Fixed false pass if regex meta chars used

### DIFF
--- a/src/masonite/validation/Validator.py
+++ b/src/masonite/validation/Validator.py
@@ -759,10 +759,16 @@ class strong(BaseValidation):
                 all_clear = False
 
         if self.special != 0:
-            special_chars = "[^A-Za-z0-9]"
+            # custom specials are just a string of characters
+            # and may contain regex meta chars.
+            # so we search for them differently
             if self.special_chars:
-                special_chars = f"[{self.special_chars}]"
-            if len(re.findall(special_chars, attribute)) < self.special:
+                special_count = sum(attribute.count(c) for c in self.special_chars)
+            else:
+                std_specials = "[^A-Za-z0-9]"
+                special_count = len(re.findall(std_specials, attribute))
+
+            if special_count < self.special:
                 self.special_check = False
                 all_clear = False
 

--- a/tests/features/validation/test_validation.py
+++ b/tests/features/validation/test_validation.py
@@ -1677,14 +1677,26 @@ class TestValidationProvider(TestCase):
         # test custom special characters
         validate = Validator().validate(
             {
-                "password": "secret&-",
+                "password": "$e]cret&-",
             },
-            strong(["password"], length=5, uppercase=0, special=2, special_chars="*&^", numbers=0, lowercase=4),
+            strong(
+                ["password"],
+                length=5,
+                uppercase=0,
+                special=4,
+                special_chars="^$*&()[]",
+                numbers=0,
+                lowercase=4,
+            ),
         )
 
         self.assertEqual(
             validate.all(),
-            {"password": ["The password field must contain at least 2 of these characters: '*&^'"]},
+            {
+                "password": [
+                    "The password field must contain at least 4 of these characters: '^$*&()[]'"
+                ]
+            },
         )
 
         validate = Validator().validate(


### PR DESCRIPTION
providing a list of regex meta charscters could cause a false pass for validation

by checking if the characters in the special chars exist without using regex we avoid this issue entirely 