### PR TITLE
Fix/redis cache issues

### DIFF
--- a/src/masonite/cache/drivers/RedisDriver.py
+++ b/src/masonite/cache/drivers/RedisDriver.py
@@ -6,7 +6,6 @@ if TYPE_CHECKING:
     from redis import Redis
 
 
-
 class RedisDriver:
     def __init__(self, application):
         self.application = application
@@ -165,7 +164,7 @@ class RedisDriver:
         self._internal_cache.pop(key)
 
     def flush(self) -> None:
-        flushed = self.get_connection().flushall()
+        self.get_connection().flushall()
         self._internal_cache = None
 
     def get_default_timeout(self) -> int:

--- a/src/masonite/cache/drivers/RedisDriver.py
+++ b/src/masonite/cache/drivers/RedisDriver.py
@@ -86,8 +86,8 @@ class RedisDriver:
         if not self.has(key):
             return default or None
 
-        key_expires = self._internal_cache[key].get("expires", None)
-        if key_expires is None:
+        key_expiry = self._internal_cache[key].get("expires", None)
+        if key_expiry is None:
             # the ttl value can also provide info on the
             # existence of the key in the store
             ttl = self.get_connection().ttl(key)
@@ -99,9 +99,9 @@ class RedisDriver:
                 self._internal_cache.pop(key)
                 return default or None
 
-            self._internal_cache[key]["expires"] = self._expires_from_ttl(ttl)
+            key_expiry = self._expires_from_ttl(ttl)
+            self._internal_cache[key]["expires"] = key_expiry
 
-        key_expiry = self._internal_cache[key].get("expires")
         if pdlm.now() > key_expiry:
             # the key has expired so remove it from the cache
             self._internal_cache.pop(key)

--- a/tests/features/cache/test_redis_cache.py
+++ b/tests/features/cache/test_redis_cache.py
@@ -11,7 +11,7 @@ class TestRedisCache(TestCase):
         self.application.make("cache")
         self.driver = self.application.make("cache").store("redis")
 
-    def test_can_add_file_driver(self):
+    def test_can_add_redis_driver(self):
         self.assertEqual(self.driver.add("add_key", "value"), "value")
 
     def test_can_get_driver(self):
@@ -23,9 +23,13 @@ class TestRedisCache(TestCase):
         self.driver.put("count", "1")
         self.assertEqual(self.driver.get("count"), "1")
         self.driver.increment("count")
-        self.assertEqual(self.driver.get("count"), "2")
+        self.assertEqual(self.driver.get("count"), 2)
+        self.driver.increment("count", 3)
+        self.assertEqual(self.driver.get("count"), 5)
         self.driver.decrement("count")
-        self.assertEqual(self.driver.get("count"), "1")
+        self.assertEqual(self.driver.get("count"), 4)
+        self.driver.decrement("count", 2)
+        self.assertEqual(self.driver.get("count"), 2)
 
     def test_will_not_get_expired(self):
         self.driver.put("expire", "1", 1)


### PR DESCRIPTION
Refactored Redis Cache Driver

- Fixed internal cache not always loaded on first cache access
- added ability to define “timeout” for for key expiry
- - defaults to a ttl of 1 month.  
- - Previous hardcoded value was 10 years!
- correctly store and unpack int types
- fix internal cache not removed if store was flushed
- fixed an issue where an imternal cache key would not be updated if it existed, but would be updated in the Redis store
- added expiring of internal cache keys