### PR TITLE
opt-out of encrypt for a cookie

### DIFF
--- a/src/masonite/cookies/Cookie.py
+++ b/src/masonite/cookies/Cookie.py
@@ -9,6 +9,7 @@ class Cookie:
         timezone=None,
         secure=False,
         samesite="Strict",
+        encrypt=True,
     ):
         self.name = name
         self.value = value
@@ -18,6 +19,7 @@ class Cookie:
         self.timezone = timezone
         self.samesite = samesite
         self.path = path
+        self.encrypt = encrypt
 
     def render(self):
         response = f"{self.name}={self.value};"

--- a/src/masonite/middleware/route/EncryptCookies.py
+++ b/src/masonite/middleware/route/EncryptCookies.py
@@ -4,6 +4,9 @@ from ...exceptions import InvalidToken
 class EncryptCookies:
     def before(self, request, response):
         for _, cookie in request.cookie_jar.all().items():
+            if not cookie.encrypt:
+                continue
+
             try:
                 cookie.value = request.app.make("sign").unsign(cookie.value)
             except InvalidToken:
@@ -13,6 +16,9 @@ class EncryptCookies:
 
     def after(self, request, response):
         for _, cookie in response.cookie_jar.all().items():
+            if not cookie.encrypt:
+                continue
+
             try:
                 cookie.value = request.app.make("sign").sign(cookie.value)
             except InvalidToken:

--- a/tests/core/middleware/test_encrypt_cookies.py
+++ b/tests/core/middleware/test_encrypt_cookies.py
@@ -16,7 +16,7 @@ class TestEncryptCookiesMiddleware(TestCase):
         EncryptCookies().after(request, response)
         self.assertNotEqual(response.cookie("test"), "value")
 
-def test_encrypt_cookies_opt_out(self):
+    def test_encrypt_cookies_opt_out(self):
         request = self.make_request(
             {"HTTP_COOKIE": f"test_key=test value"}
         )

--- a/tests/core/middleware/test_encrypt_cookies.py
+++ b/tests/core/middleware/test_encrypt_cookies.py
@@ -15,3 +15,16 @@ class TestEncryptCookiesMiddleware(TestCase):
         response.cookie("test", "value")
         EncryptCookies().after(request, response)
         self.assertNotEqual(response.cookie("test"), "value")
+
+def test_encrypt_cookies_opt_out(self):
+        request = self.make_request(
+            {"HTTP_COOKIE": f"test_key=test value"}
+        )
+
+        response = self.make_response()
+        EncryptCookies().before(request, None)
+        self.assertEqual(request.cookie("test_key", encrypt=False), "test value")
+
+        response.cookie("test", "value")
+        EncryptCookies().after(request, response)
+        self.assertNotEqual(response.cookie("test_key", encrypt=False), "test value")


### PR DESCRIPTION
Addresses #813 

Adds an additional bool parameter to the cookie "encrypt"
defaults to True

When set to False the value is not encrypted before adding it to the request/response.
This allows data (JSON) strings to be parsed and used on the client side
