### PR TITLE
Fix session errors and View errors() helper always empty

### DIFF
--- a/src/masonite/middleware/route/SessionMiddleware.py
+++ b/src/masonite/middleware/route/SessionMiddleware.py
@@ -16,13 +16,15 @@ class SessionMiddleware(Middleware):
         request.app.make("response").with_success = self.with_success
         request.app.make("request").session = Session
 
-        # TODO: Remove in Masonite 5
-        errors = Session.get("errors") or {}
-        request.app.make("view").share({"errors": MessageBag(errors).helper})
-        # errors are stored in session flash so 'getting' them actually clears them
-        # if any then re-add them to the session
+        # TODO: Check this in Masonite 5
+        # errors are stored in session flash so 'getting' them
+        # actually clears them out of the session
+        errors = Session.get("errors")
+        request.app.make("view").share({"errors": MessageBag(errors or {}).helper})
+        # if any errors then re-add them to the session
         if errors:
-            Session.flash('errors', errors)
+            Session.flash("errors", errors)
+
         return request
 
     def after(self, request, _):

--- a/src/masonite/middleware/route/SessionMiddleware.py
+++ b/src/masonite/middleware/route/SessionMiddleware.py
@@ -17,7 +17,11 @@ class SessionMiddleware(Middleware):
         request.app.make("request").session = Session
 
         # TODO: Remove in Masonite 5
-        request.app.make("view").share({"bag": MessageBag(Session.get("errors") or {}).helper})
+        bag = MessageBag(Session.get("errors") or {})
+        request.app.make("view").share({"errors": bag.helper})
+        # errors are stored in session flash so 'getting' them actually clears them
+        # so re-add them to the session as a MessageBag
+        Session.flash('errors', bag)
         return request
 
     def after(self, request, _):

--- a/src/masonite/middleware/route/SessionMiddleware.py
+++ b/src/masonite/middleware/route/SessionMiddleware.py
@@ -17,11 +17,12 @@ class SessionMiddleware(Middleware):
         request.app.make("request").session = Session
 
         # TODO: Remove in Masonite 5
-        bag = MessageBag(Session.get("errors") or {})
-        request.app.make("view").share({"errors": bag.helper})
+        errors = Session.get("errors") or {}
+        request.app.make("view").share({"errors": MessageBag(errors).helper})
         # errors are stored in session flash so 'getting' them actually clears them
-        # so re-add them to the session as a MessageBag
-        Session.flash('errors', bag)
+        # if any then re-add them to the session
+        if errors:
+            Session.flash('errors', errors)
         return request
 
     def after(self, request, _):

--- a/tests/core/response/test_response_helpers.py
+++ b/tests/core/response/test_response_helpers.py
@@ -45,6 +45,9 @@ class TestResponseWithMiddleware(TestCase):
         )
 
     def test_with_errors(self):
-        self.get("/test-with-errors").assertSessionHasErrors().assertSessionHasErrors(
-            ["email"]
+        (
+            self.get("/test-with-errors")
+            .assertSessionHasErrors()
+            .assertSessionHasErrors(["email"])
+            .assertSessionHasNoErrors()
         )

--- a/tests/core/response/test_response_helpers.py
+++ b/tests/core/response/test_response_helpers.py
@@ -1,5 +1,6 @@
-from tests import TestCase
+from src.masonite.middleware import SessionMiddleware
 from src.masonite.routes import Route
+from tests import TestCase
 
 
 class TestResponseHelpers(TestCase):
@@ -12,6 +13,36 @@ class TestResponseHelpers(TestCase):
 
     def test_with_input(self):
         self.get("/test-with-input", {"name": "Sam"}).assertSessionHas("name", "Sam")
+
+    def test_with_errors(self):
+        self.get("/test-with-errors").assertSessionHasErrors().assertSessionHasErrors(
+            ["email"]
+        )
+
+
+class TestResponseWithMiddleware(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.application.make("middleware").add(
+            {
+                "web": SessionMiddleware,
+            }
+        )
+        self.addRoutes(
+            Route.get("/test-with-errors", "WelcomeController@with_errors").middleware(
+                "web"
+            ),
+            Route.get(
+                "/test-with-input", "WelcomeController@form_with_input"
+            ).middleware("web"),
+        )
+
+    def test_with_input(self):
+        (
+            self.get("/test-with-input", {"name": "Sam"})
+            .assertSessionHas("name", "Sam")
+            .assertSessionHasNoErrors()
+        )
 
     def test_with_errors(self):
         self.get("/test-with-errors").assertSessionHasErrors().assertSessionHasErrors(


### PR DESCRIPTION
@josephmancuso 

Sorry I broke this PR badly and had to recreate it so we have lost the chat history ;(. 

This PR addresses #816: 
> moves the MessageBag helper in the View from 'bag()'
back to its documented expected value 'errors()'
> adds the "errors" key back into the session for backwards compatibility.

One thing I would ask is:
> Is there any reason not to have the errors added back to the session as a MessageBag?
> This makes SharedErrorsInSessionMiddleware a bit redundant... 

Happy to discuss

will add Tests for SessionMiddleware soon