### PR TITLE
Refactor RateLimiter.py to use hyphen instead of colon in cache keys

### DIFF
--- a/src/masonite/rates/RateLimiter.py
+++ b/src/masonite/rates/RateLimiter.py
@@ -46,8 +46,8 @@ class RateLimiter:
         key = self.clean_key(key)
         if self.attempts(key) >= max_attempts:
             # trigger remove of cache value if needed
-            self.cache.get(f"{key}:timer")
-            if self.cache.has(f"{key}:timer"):
+            self.cache.get(f"{key}-timer")
+            if self.cache.has(f"{key}-timer"):
                 return True
             self.reset_attempts(key)
         return False
@@ -56,7 +56,7 @@ class RateLimiter:
         key = self.clean_key(key)
         # store timestamp when key limit be available again
         available_at = pendulum.now().add(seconds=delay).int_timestamp
-        self.cache.add(f"{key}:timer", available_at, delay)
+        self.cache.add(f"{key}-timer", available_at, delay)
         # ensure key exists
         self.cache.add(key, 0, delay)
         hits = self.cache.increment(key)
@@ -69,12 +69,12 @@ class RateLimiter:
     def clear(self, key: str):
         key = self.clean_key(key)
         self.cache.forget(key)
-        self.cache.forget(f"{key}:timer")
+        self.cache.forget(f"{key}-timer")
 
     def available_at(self, key: str) -> int:
         """Get UNIX integer timestamp at which key will be available again."""
         key = self.clean_key(key)
-        timestamp = int(self.cache.get(f"{key}:timer", 0))
+        timestamp = int(self.cache.get(f"{key}-timer", 0))
         return timestamp
 
     def available_in(self, key: str) -> int:

--- a/tests/features/rates/test_rate_limiter.py
+++ b/tests/features/rates/test_rate_limiter.py
@@ -24,9 +24,9 @@ class TestRateLimiter(TestCase):
     def test_clear_remove_cache_keys(self):
         RateLimiter.attempt("test_key", my_function, 2)
         assert Cache.store().has("test_key")
-        assert Cache.store().has("test_key:timer")
+        assert Cache.store().has("test_key-timer")
         RateLimiter.clear("test_key")
-        assert not Cache.store().has("test_key:timer")
+        assert not Cache.store().has("test_key-timer")
         assert not Cache.store().has("test_key")
 
     def test_reset_attempts(self):
@@ -50,7 +50,7 @@ class TestRateLimiter(TestCase):
         should_be_available_at = now.add(seconds=40)
         RateLimiter.hit("test_key", 40)
         assert Cache.store().get("test_key") == "1"
-        assert Cache.store().get("test_key:timer") == str(
+        assert Cache.store().get("test_key-timer") == str(
             should_be_available_at.int_timestamp
         )
 


### PR DESCRIPTION
Closes #759 