### PR TITLE
fix: Update dependencies for Python 3.12 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,14 +4,14 @@ black
 cleo>=0.8.1,<0.9
 cryptography>=36,<37
 dotty_dict>=1.3.0,<1.40
-exceptionite>=2.0,<3
+exceptionite>=2.0,<4
 hashids>=1.3,<1.4
 hfilesize>=0.1
 hupper>=1.10,<1.11
 inflection>=0.3,<0.4
 jinja2<3.2
 masonite-orm>=2,<3
-pendulum>=2,<3
+pendulum>=3,<4
 pwnedapi
 vonage>=3,<4
 pytest

--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,8 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
         "inflection>=0.3,<0.4",
-        "exceptionite>=2.2,<3.0",
-        "pendulum>=2,<3",
+        "exceptionite>=2.2,<4",
+        "pendulum>=3,<4",
         "jinja2<3.2",
         "cleo>=0.8.1,<0.9",
         "hupper>=1.10,<1.11",


### PR DESCRIPTION
- Update pendulum from >=2,<3 to >=3,<4 (pendulum 2.x lacks pre-built wheels for Python 3.12)
- Update exceptionite from >=2.2,<3.0 to >=2.2,<4 (exceptionite 2.2.5 has pkg_resources compatibility issues on Python 3.12)

Fixes ModuleNotFoundError: No module named 'distutils' and 'pkg_resources' errors when running on Python 3.12.