### PR TITLE
Feature: add email verification (Laravel-style MustVerifyEmail)

### DIFF
--- a/src/masonite/auth/MustVerifyEmail.py
+++ b/src/masonite/auth/MustVerifyEmail.py
@@ -2,25 +2,41 @@
 
 import time
 
+import pendulum
+
 from ..auth.Sign import Sign
 
 
 class MustVerifyEmail:
-    """Class To Verify User Email."""
+    """Mixin that adds email verification to a User model."""
 
     def verify_email(self, mail_manager, request):
-        """Sends email for user verification
+        from masonite.mail import Mailable
+        from masonite.configuration import config
 
-        Arguments:
-            mail_manager {masonite.managers.MailManager} -- Masonite mail manager class.
-            request {masonite.request.Request} -- Masonite request class.
-        """
-        mail = mail_manager.helper()
         sign = Sign()
-
         token = sign.sign("{0}::{1}".format(self.id, time.time()))
-        link = "{0}/email/verify/{1}".format(request.environ["HTTP_HOST"], token)
+        scheme = request.environ.get("wsgi.url_scheme", "http")
+        host = request.environ.get("HTTP_HOST", "localhost")
+        link = "{0}://{1}/email/verify/{2}".format(scheme, host, token)
+        user_name = getattr(self, "name", "")
 
-        mail.to(self.email).template(
-            "auth/verifymail", {"name": self.name, "email": self.email, "link": link}
-        ).subject("Please Confirm Your Email").send()
+        class _VerifyEmail(Mailable):
+            def build(self):
+                return (
+                    self.subject("Please Confirm Your Email")
+                    .from_(config("mail.from_address"))
+                    .view(
+                        "auth.mailables.verify_email",
+                        {"name": user_name, "link": link},
+                    )
+                )
+
+        mail_manager.mailable(_VerifyEmail().to(self.email)).send()
+
+    def has_verified_email(self):
+        return self.verified_at is not None
+
+    def mark_email_as_verified(self):
+        self.verified_at = pendulum.now().to_datetime_string()
+        self.save()

--- a/src/masonite/authentication/Auth.py
+++ b/src/masonite/authentication/Auth.py
@@ -192,4 +192,13 @@ class Auth:
                 "auth.PasswordResetController@store_changed_password",
             ).name("change_password.store"),
             Route.post("/login", "auth.LoginController@store").name("login.store"),
+            Route.get("/email/verify/notice", "auth.VerifyEmailController@notice").name(
+                "verification.notice"
+            ),
+            Route.get(
+                "/email/verify/@token", "auth.VerifyEmailController@verify"
+            ).name("verification.verify"),
+            Route.post("/email/resend", "auth.VerifyEmailController@resend")
+            .name("verification.resend")
+            .middleware("auth"),
         ]

--- a/src/masonite/middleware/VerifiesEmailMiddleware.py
+++ b/src/masonite/middleware/VerifiesEmailMiddleware.py
@@ -1,0 +1,14 @@
+from .middleware import Middleware
+
+
+class VerifiesEmailMiddleware(Middleware):
+    def before(self, request, response):
+        user = request.user()
+        if not user:
+            return response.redirect("/login")
+        if not hasattr(user, "has_verified_email") or not user.has_verified_email():
+            return response.redirect("/email/verify/notice")
+        return request
+
+    def after(self, request, response):
+        return request

--- a/src/masonite/middleware/__init__.py
+++ b/src/masonite/middleware/__init__.py
@@ -13,3 +13,4 @@ from .route.ClearDumpsBetweenRequestsMiddleware import (
 from .route.ThrottleRequestsMiddleware import ThrottleRequestsMiddleware
 from .route.IpMiddleware import IpMiddleware
 from .route.CorsMiddleware import CorsMiddleware
+from .VerifiesEmailMiddleware import VerifiesEmailMiddleware

--- a/src/masonite/stubs/controllers/auth/RegisterController.py
+++ b/src/masonite/stubs/controllers/auth/RegisterController.py
@@ -3,6 +3,7 @@ from masonite.views import View
 from masonite.request import Request
 from masonite.response import Response
 from masonite.authentication import Auth
+from masonite.facades import Mail
 
 
 class RegisterController(Controller):
@@ -27,5 +28,9 @@ class RegisterController(Controller):
 
         if not user:
             return response.redirect("/register")
+
+        if hasattr(user, "verify_email"):
+            user.verify_email(Mail, request)
+            return response.redirect("/email/verify/notice")
 
         return response.redirect("/home")

--- a/src/masonite/stubs/controllers/auth/VerifyEmailController.py
+++ b/src/masonite/stubs/controllers/auth/VerifyEmailController.py
@@ -1,0 +1,56 @@
+from masonite.controllers import Controller
+from masonite.request import Request
+from masonite.response import Response
+from masonite.authentication import Auth
+from masonite.auth import Sign
+from masonite.exceptions import InvalidToken
+from masonite.facades import Mail
+
+
+class VerifyEmailController(Controller):
+    def verify(self, request: Request, response: Response, auth: Auth):
+        token = request.param("token")
+        sign = Sign()
+
+        try:
+            payload = sign.unsign(token)
+        except InvalidToken:
+            return response.redirect("/email/verify/notice").with_errors(
+                ["Invalid or expired verification link."]
+            )
+
+        user_id = payload.split("::")[0]
+        user = auth.attempt_by_id(user_id, once=True)
+
+        if not user:
+            return response.redirect("/login")
+
+        if user.has_verified_email():
+            return response.redirect("/home")
+
+        user.mark_email_as_verified()
+        request.app().make("event").fire("auth.email_verified", user)
+
+        return response.redirect("/home").with_success(
+            ["Your email has been verified."]
+        )
+
+    def notice(self, request: Request, response: Response, auth: Auth):
+        if auth.user() and auth.user().has_verified_email():
+            return response.redirect("/home")
+        return response.view("auth.verify_email_notice")
+
+    def resend(self, request: Request, response: Response, auth: Auth):
+        user = auth.user()
+
+        if not user:
+            return response.redirect("/login")
+
+        if user.has_verified_email():
+            return response.redirect("/home")
+
+        user.verify_email(Mail, request)
+
+        return response.back().with_success(
+            ["A fresh verification link has been sent to your email address."]
+        )

--- a/src/masonite/stubs/templates/auth/mailables/verify_email.html
+++ b/src/masonite/stubs/templates/auth/mailables/verify_email.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Verify Email Address</title>
+    <style>
+        html { background-color: #CBD5E1; }
+        .button {
+            color: white;
+            padding: 10px 20px;
+            background-color: #1F2937;
+            margin-top: 15px;
+            text-decoration: none;
+            display: inline-block;
+        }
+    </style>
+</head>
+<body>
+    <div style="width: 98%; background-color: white; margin-right: 10px; padding: 10px">
+        <h4>Hello, {{ name }}</h4>
+        <p>Please click the button below to verify your email address.</p>
+        <a href="{{ link }}" class="button">Verify Email Address</a>
+        <p style="margin-top: 20px; color: #6B7280; font-size: 0.875rem;">
+            If you did not create an account, no further action is required.
+        </p>
+    </div>
+</body>
+</html>

--- a/src/masonite/stubs/templates/auth/verify_email_notice.html
+++ b/src/masonite/stubs/templates/auth/verify_email_notice.html
@@ -1,0 +1,27 @@
+{% extends "auth/base.html" %}
+{% block content %}
+<div class="min-h-screen flex items-center justify-center bg-gray-100">
+    <div class="max-w-md w-full bg-white rounded shadow p-8">
+        <h2 class="text-2xl font-bold mb-4">Verify Your Email Address</h2>
+
+        {% if session.has('success') %}
+            <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-4">
+                {{ session.get('success')|join('') }}
+            </div>
+        {% endif %}
+
+        <p class="text-gray-600 mb-6">
+            Before proceeding, please check your email for a verification link.
+            If you did not receive the email, click below to request another.
+        </p>
+
+        <form method="POST" action="/email/resend">
+            {{ csrf_field }}
+            <button type="submit"
+                class="w-full bg-gray-800 text-white py-2 px-4 rounded hover:bg-gray-700">
+                Resend Verification Email
+            </button>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/tests/core/authentication/test_email_verification.py
+++ b/tests/core/authentication/test_email_verification.py
@@ -1,0 +1,195 @@
+import inspect
+import unittest
+from unittest.mock import MagicMock, patch
+
+from src.masonite.auth import Sign, MustVerifyEmail
+from src.masonite.exceptions import InvalidToken
+from src.masonite.middleware import VerifiesEmailMiddleware
+
+# A stable Fernet key used only in tests so Sign() never touches wsgi
+TEST_KEY = "ODgUEaNUZqBweffQP9Rw1U_KEqL2EIcgjfQIsLPnL6g="
+
+
+class MockUser(MustVerifyEmail):
+    """Minimal user stub that mixes in MustVerifyEmail."""
+
+    def __init__(self, user_id=1, email="user@example.com", name="Test", verified_at=None):
+        self.id = user_id
+        self.email = email
+        self.name = name
+        self.verified_at = verified_at
+        self._saved = False
+
+    def save(self):
+        self._saved = True
+
+
+# ---------------------------------------------------------------------------
+# MustVerifyEmail mixin
+# ---------------------------------------------------------------------------
+
+class TestMustVerifyEmailMixin(unittest.TestCase):
+
+    def test_unverified_user_returns_false(self):
+        self.assertFalse(MockUser(verified_at=None).has_verified_email())
+
+    def test_verified_user_returns_true(self):
+        self.assertTrue(MockUser(verified_at="2026-01-01 00:00:00").has_verified_email())
+
+    def test_mark_email_as_verified_sets_timestamp(self):
+        user = MockUser(verified_at=None)
+        user.mark_email_as_verified()
+        self.assertIsNotNone(user.verified_at)
+
+    def test_mark_email_as_verified_calls_save(self):
+        user = MockUser(verified_at=None)
+        user.mark_email_as_verified()
+        self.assertTrue(user._saved)
+
+    def test_mark_email_as_verified_makes_has_verified_email_true(self):
+        user = MockUser(verified_at=None)
+        user.mark_email_as_verified()
+        self.assertTrue(user.has_verified_email())
+
+    def test_verify_email_sends_mail(self):
+        user = MockUser()
+        mail_manager = MagicMock()
+        request = MagicMock()
+        request.environ = {"wsgi.url_scheme": "http", "HTTP_HOST": "localhost"}
+
+        with patch("src.masonite.auth.MustVerifyEmail.Sign", lambda: Sign(key=TEST_KEY)):
+            user.verify_email(mail_manager, request)
+
+        mail_manager.mailable.assert_called_once()
+        mail_manager.mailable.return_value.send.assert_called_once()
+
+    def test_verify_email_token_contains_user_id(self):
+        """Token must unsign to a payload that starts with the user id."""
+        user = MockUser(user_id=42)
+        mail_manager = MagicMock()
+        request = MagicMock()
+        request.environ = {"wsgi.url_scheme": "http", "HTTP_HOST": "localhost"}
+
+        with patch("src.masonite.auth.MustVerifyEmail.Sign") as MockSign:
+            user.verify_email(mail_manager, request)
+            raw_value = MockSign.return_value.sign.call_args[0][0]
+
+        self.assertTrue(raw_value.startswith("42::"))
+
+    def test_verify_email_uses_correct_recipient(self):
+        user = MockUser(email="jane@example.com")
+        captured = {}
+
+        def capture(mailable):
+            captured["mailable"] = mailable
+            return MagicMock()
+
+        mail_manager = MagicMock()
+        mail_manager.mailable.side_effect = capture
+        request = MagicMock()
+        request.environ = {"wsgi.url_scheme": "http", "HTTP_HOST": "localhost"}
+
+        with patch("src.masonite.auth.MustVerifyEmail.Sign"):
+            user.verify_email(mail_manager, request)
+
+        # Mailable stores the recipient in _to (set via .to())
+        self.assertEqual(captured["mailable"]._to, "jane@example.com")
+
+
+# ---------------------------------------------------------------------------
+# Sign utility
+# ---------------------------------------------------------------------------
+
+class TestSign(unittest.TestCase):
+
+    def setUp(self):
+        self.sign = Sign(key=TEST_KEY)
+
+    def test_sign_and_unsign_round_trip(self):
+        original = "42::1716000000.0"
+        self.assertEqual(self.sign.unsign(self.sign.sign(original)), original)
+
+    def test_unsign_invalid_token_raises(self):
+        with self.assertRaises(InvalidToken):
+            self.sign.unsign("not-a-valid-token")
+
+    def test_different_values_produce_different_tokens(self):
+        self.assertNotEqual(self.sign.sign("1::1000"), self.sign.sign("2::1000"))
+
+
+# ---------------------------------------------------------------------------
+# VerifiesEmailMiddleware
+# ---------------------------------------------------------------------------
+
+class TestVerifiesEmailMiddleware(unittest.TestCase):
+
+    def setUp(self):
+        self.middleware = VerifiesEmailMiddleware()
+
+    def _mock_request_response(self, user=None):
+        request = MagicMock()
+        request.user.return_value = user
+        response = MagicMock()
+        return request, response
+
+    def test_unauthenticated_user_is_redirected_to_login(self):
+        request, response = self._mock_request_response(user=None)
+        self.middleware.before(request, response)
+        response.redirect.assert_called_once_with("/login")
+
+    def test_unverified_user_is_redirected_to_notice(self):
+        user = MockUser(verified_at=None)
+        request, response = self._mock_request_response(user=user)
+        self.middleware.before(request, response)
+        response.redirect.assert_called_once_with("/email/verify/notice")
+
+    def test_verified_user_passes_through(self):
+        user = MockUser(verified_at="2026-01-01 00:00:00")
+        request, response = self._mock_request_response(user=user)
+        result = self.middleware.before(request, response)
+        response.redirect.assert_not_called()
+        self.assertEqual(result, request)
+
+    def test_user_without_mixin_is_redirected_to_notice(self):
+        plain_user = object()  # no has_verified_email attribute
+        request, response = self._mock_request_response(user=plain_user)
+        self.middleware.before(request, response)
+        response.redirect.assert_called_once_with("/email/verify/notice")
+
+    def test_after_always_passes_through(self):
+        request, response = self._mock_request_response()
+        self.assertEqual(self.middleware.after(request, response), request)
+
+
+# ---------------------------------------------------------------------------
+# Auth.routes() includes verification routes
+# Inspect source rather than calling Auth.routes() to avoid wsgi bootstrap.
+# ---------------------------------------------------------------------------
+
+class TestAuthRoutesIncludeVerification(unittest.TestCase):
+
+    def setUp(self):
+        from src.masonite.authentication import Auth
+        self.source = inspect.getsource(Auth.routes)
+
+    def test_verification_notice_route_defined(self):
+        self.assertIn("verification.notice", self.source)
+
+    def test_verification_verify_route_defined(self):
+        self.assertIn("verification.verify", self.source)
+
+    def test_verification_resend_route_defined(self):
+        self.assertIn("verification.resend", self.source)
+
+    def test_verify_route_has_token_param(self):
+        self.assertIn("/email/verify/@token", self.source)
+
+    def test_resend_route_is_post(self):
+        # The resend route must use Route.post
+        resend_idx = self.source.index("verification.resend")
+        snippet = self.source[max(0, resend_idx - 200):resend_idx]
+        self.assertIn("Route.post", snippet)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a complete email verification system to Masonite, similar to Laravel's
`MustVerifyEmail` trait. Previously, `MustVerifyEmail` existed as an orphaned
utility class with no routes, middleware, controller, or integration with the
registration flow. This PR wires everything together.

## What's added

**`MustVerifyEmail` mixin** (`src/masonite/auth/MustVerifyEmail.py`)
- `has_verified_email()` — checks if `verified_at` is set
- `mark_email_as_verified()` — stamps `verified_at` and saves the model
- `verify_email()` — sends a signed verification link via mail

**`VerifiesEmailMiddleware`** (`src/masonite/middleware/VerifiesEmailMiddleware.py`)
- Add `"verified"` to any route to block unverified users
- Redirects unauthenticated users to `/login`, unverified users to `/email/verify/notice`
- Exported from `masonite.middleware`

**`VerifyEmailController` stub** (`src/masonite/stubs/controllers/auth/`)
- `notice` — shows the "check your inbox" page
- `verify` — validates the signed token and marks the email as verified
- `resend` — sends a fresh verification link to the authenticated user

**Routes** — `Auth.routes()` now includes:
- `GET /email/verify/notice` → `verification.notice`
- `GET /email/verify/@token` → `verification.verify`
- `POST /email/resend` → `verification.resend`

**Templates**
- `auth/mailables/verify_email.html` — the verification email
- `auth/verify_email_notice.html` — the notice page with a resend button

**`RegisterController` stub** — automatically sends a verification email after
registration if the User model mixes in `MustVerifyEmail`, and redirects to
the notice page instead of `/home`.

## Usage

```python
# 1. Mix into your User model
from masonite.auth import MustVerifyEmail

class User(Model, Authenticates, MustVerifyEmail):
    pass
```

```python
# 2. Gate routes that require a verified email
Route.get("/dashboard", "DashboardController@show").middleware("auth", "verified")
```

```python
# 3. Register the middleware key in your Kernel
self.application.make("middleware").add({"verified": VerifiesEmailMiddleware})
```

## Tests

21 unit tests added in `tests/core/authentication/test_email_verification.py`:
- `MustVerifyEmail` mixin behaviour (5 tests)
- `verify_email()` — mail is sent, token contains user id, correct recipient (3 tests)
- `Sign` utility — round-trip, invalid token, uniqueness (3 tests)
- `VerifiesEmailMiddleware` — all redirect and pass-through cases (5 tests)
- `Auth.routes()` — all 3 verification routes are defined (5 tests)

All 21 tests pass.

## Checklist

- [x] Feature parity with Laravel's email verification flow
- [x] Opt-in via mixin — no breaking changes to existing projects
- [x] Works with existing `Sign`, `Mail`, and event system
- [x] Tests included and passing