### PR TITLE
Deprecate this repository: Masonite continues at masonitedev/masonite

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -8,38 +8,17 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
-      - name: Install dependencies
-        env:
-          MAIL_HOST: ${{ github.secrets.MAIL_HOST }}
-          MAIL_PORT: ${{ github.secrets.MAIL_PORT }}
-          MAIL_USERNAME: ${{ github.secrets.MAIL_USERNAME }}
-          MAIL_PASSWORD: ${{ github.secrets.MAIL_PASSWORD }}
-          DB_CONFIG_PATH: tests/integrations/config/database
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel twine
-          make init
-          make ci
+          python-version: "3.10"
       - name: Build and publish
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-          MAIL_HOST: ${{ github.secrets.MAIL_HOST }}
-          MAIL_PORT: ${{ github.secrets.MAIL_PORT }}
-          MAIL_USERNAME: ${{ github.secrets.MAIL_USERNAME }}
-          MAIL_PASSWORD: ${{ github.secrets.MAIL_PASSWORD }}
-          DB_CONFIG_PATH: tests/integrations/config/database
         run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
           python setup.py sdist bdist_wheel
           twine upload dist/*
-      - name: Discord notification
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-        uses: Ilshidur/action-discord@master
-        with:
-          args: "{{ EVENT_PAYLOAD.repository.full_name }} {{ EVENT_PAYLOAD.release.tag_name }} has been released. Checkout the full release notes here: {{ EVENT_PAYLOAD.release.html_url }}"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+# ⚠️ This repository is no longer maintained
+
+> **Masonite development continues at [masonitedev/masonite](https://github.com/masonitedev/masonite).**
+> Masonite 5 is published on PyPI as [**`masonite-framework`**](https://pypi.org/project/masonite-framework/).
+> This repository covers Masonite ≤ 4.x and will receive **no further updates** (including security fixes).
+>
+> - 📖 Documentation: <https://docs.masonite.dev>
+> - ⬆️ [Upgrade guide: Masonite 4.0 → 5.0](https://docs.masonite.dev/upgrade-guide/masonite-4.0-to-5.0/)
+>
+> ❤️ In memory of [Joseph "Joe" Mancuso](https://github.com/josephmancuso), creator of Masonite.
+
+---
+
 <p align="center">
   <img src="https://dev-to-uploads.s3.amazonaws.com/uploads/articles/4trhpkkdbbzutc5ufxi9.png" width="160px">
   <h1 align="center">Masonite</h1>

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         #   3 - Alpha
         #   4 - Beta
         #   5 - Production/Stable
-        "Development Status :: 5 - Production/Stable",
+        "Development Status :: 7 - Inactive",
         # Indicate who your project is intended for
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Build Tools",

--- a/src/masonite/__init__.py
+++ b/src/masonite/__init__.py
@@ -1,1 +1,12 @@
+import warnings
+
 __version__ = "4.20.3"
+
+warnings.warn(
+    "The 'masonite' package is unmaintained and will receive no further updates. "
+    "Masonite 5 continues as 'masonite-framework' "
+    "(https://github.com/masonitedev/masonite). Upgrade guide: "
+    "https://docs.masonite.dev/upgrade-guide/masonite-4.0-to-5.0/",
+    FutureWarning,
+    stacklevel=2,
+)


### PR DESCRIPTION
## Masonite has moved

Masonite 5 is developed at [masonitedev/masonite](https://github.com/masonitedev/masonite) and published on PyPI as [`masonite-framework`](https://pypi.org/project/masonite-framework/). This repository covers Masonite ≤ 4.x and will receive no further updates.

This PR:

- Adds a deprecation banner to the README (which is also the PyPI project page), pointing to the new organization, the new package name, the new documentation at https://docs.masonite.dev and the [4.0 → 5.0 upgrade guide](https://docs.masonite.dev/upgrade-guide/masonite-4.0-to-5.0/) — in memory of Joe Mancuso ❤️
- Emits a `FutureWarning` when `masonite` is imported so running 4.x applications learn about the move (one line per process, silenceable with standard warnings filters)
- Marks the package `Development Status :: 7 - Inactive`
- Hardens `pythonpublish.yml` (pin Python 3.10, build+twine only) so the final `v4.20.3` release — which also ships the 13 commits pending on this branch since v4.20.2 — can publish reliably.

After merging, a `v4.20.3` release will be created to publish the final version of the `masonite` package with this notice.