### PR TITLE
Bump version to 4.20.4 for the final deprecation release

### DIFF
--- a/src/masonite/__init__.py
+++ b/src/masonite/__init__.py
@@ -1,6 +1,6 @@
 import warnings
 
-__version__ = "4.20.3"
+__version__ = "4.20.4"
 
 warnings.warn(
     "The 'masonite' package is unmaintained and will receive no further updates. "


### PR DESCRIPTION
The `v4.20.3` tag and release already exist (March 2025) but their PyPI publish failed back then, leaving PyPI at 4.20.2. Releasing the deprecation notice as **4.20.4** avoids rewriting the existing tag. Follow-up to #864.